### PR TITLE
Fixed Email OTP authenticator when EmailOTPEnableByUserClaim is disabled

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -945,8 +945,10 @@ public class EmailOTPAuthenticator extends OpenIDConnectAuthenticator implements
             username = MultitenantUtils.getTenantAwareUsername(String.valueOf(username));
             if (userRealm != null) {
                 if (isAdminMakeUserToEnableOrDisableEmailOTP(context, parametersMap)) {
-                    String isEmailOTPEnabledByUser = userRealm.getUserStoreManager().getUserClaimValue(username,
-                            EmailOTPAuthenticatorConstants.USER_EMAILOTP_DISABLED_CLAIM_URI, null);
+                    Map<String, String> claimValues = userRealm.getUserStoreManager().getUserClaimValues(username,
+                            new String[]{EmailOTPAuthenticatorConstants.USER_EMAILOTP_DISABLED_CLAIM_URI}, null);
+                    String isEmailOTPEnabledByUser = claimValues.
+                            get(EmailOTPAuthenticatorConstants.USER_EMAILOTP_DISABLED_CLAIM_URI);
                     return Boolean.parseBoolean(isEmailOTPEnabledByUser);
                 }
             } else {

--- a/component/setup.txt
+++ b/component/setup.txt
@@ -75,7 +75,7 @@ Deploying and Configuring EmailOTP artifacts:
     (xii)  Define the Authorization token type.
                E.g: SendgridAuthTokenType=Bearer
 
-3.  Build the <EMAILOTP_AUTHENTICATOR_HOME>/component/authenticator & copy the org.wso2.carbon.extension.identity.authenticator.emailotp.connector-2.0.0.jar
-    to <IS-HOME>/repository/components/dropins
+3.  Build the <EMAILOTP_AUTHENTICATOR_HOME>/component/authenticator & copy the org.wso2.carbon.extension.identity
+.authenticator.emailotp.connector-2.0.9.jar to <IS-HOME>/repository/components/dropins
 
 4.  Follow the steps in https://docs.wso2.com/display/ISCONNECTORS/Configuring+EmailOTP+Authenticator    


### PR DESCRIPTION
## Purpose
EmailOTPEnableByUserClaim is not working after identity claim was introduced
## Goals

## Approach

## User stories
N/A
## Release note
N/A
## Documentation
N/A
## Training
N/A
## Certification
N/A
## Marketing
N/A
## Automation tests
N/A
## Security checks
Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes 
 Ran FindSecurityBugs plugin and verified report? yes
 Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
## Samples
N/A
## Related PRs
N/A
## Migrations (if applicable)
N/A
## Test environment
 JDK 1.8
Ubuntu
## Learning
N/A