### PR TITLE
Remove additional jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,28 +51,33 @@
         <dependency>
             <groupId>org.apache.rampart.wso2</groupId>
             <artifactId>rampart-core</artifactId>
+            <scope>provided</scope>
             <version>${rampart.wso2.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.rampart.wso2</groupId>
             <artifactId>rampart-policy</artifactId>
+            <scope>provided</scope>
             <version>${rampart.wso2.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.rampart.wso2</groupId>
             <artifactId>rampart-trust</artifactId>
+            <scope>provided</scope>
             <version>${rampart.wso2.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <version>${testng.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jacoco</groupId>
@@ -262,11 +267,13 @@
             <groupId>org.wso2.carbon.extension.identity.authenticator.utils</groupId>
             <artifactId>org.wso2.carbon.extension.identity.helper</artifactId>
             <version>${identity.extension.utils}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.event</artifactId>
             <version>${carbon.identity.event.version}</version>
+            <scope>provided</scope>
         </dependency>
 
 


### PR DESCRIPTION
(cherry picked from commit d4c0898)

## Purpose
> There are new jars added in the lib which caused to increase the pack size to 60 MB. I have checked with the wso2is-5.8.0m22-snapshot the functionalities are working fine

