### PR TITLE
Add authenticatedUser prop into context when usecase is undefined

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -211,6 +211,9 @@ public class EmailOTPAuthenticator extends OpenIDConnectAuthenticator implements
                             ("Authentication failed. Cannot find the subject attributed step with authenticated user.");
                 }
 
+                // Set authenticatedUser prop into context which will used in checkEmailOTPBehaviour()
+                context.setProperty(EmailOTPAuthenticatorConstants.AUTHENTICATED_USER, authenticatedUser);
+
                 if (isLocalUser) {
                     handleEmailOTPForLocalUser(username, authenticatedUser, context, emailOTPParameters,
                             isEmailOTPMandatory, queryParams, request, response);
@@ -354,6 +357,10 @@ public class EmailOTPAuthenticator extends OpenIDConnectAuthenticator implements
                             EmailOTPAuthenticatorConstants.USE_EVENT_HANDLER_BASED_EMAIL_SENDER))) {
                 AuthenticatedUser authenticatedUser = (AuthenticatedUser) context.getProperty
                         (EmailOTPAuthenticatorConstants.AUTHENTICATED_USER);
+                if (authenticatedUser == null) {
+                    throw new AuthenticationFailedException("Error occurred while triggering notification." +
+                            " Unable to find authenticated user.");
+                }
                 triggerEvent(authenticatedUser.getUserName(), authenticatedUser.getTenantDomain(),
                         authenticatedUser.getUserStoreDomain(), EmailOTPAuthenticatorConstants.EVENT_NAME, myToken, email);
             } else {


### PR DESCRIPTION
This resolves https://github.com/wso2/product-is/issues/6604 by adding the `authenticatedUser` prop into context when `usecase` is not defined to avoid the NPE in `checkEmailOTPBehaviour()`.

But it seems we may be able to handle this `authenticatedUser` value in a more clear way if we refactor the code and send `authenticatedUser` as a param to `checkEmailOTPBehaviour()`.