### PR TITLE
Changing method signature for making emailOTP customizable.

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -743,7 +743,7 @@ public class EmailOTPAuthenticator extends OpenIDConnectAuthenticator implements
      * @param context     the authentication context
      * @throws AuthenticationFailedException
      */
-    private void processEmailOTPFlow(HttpServletRequest request, HttpServletResponse response, String email,
+    protected void processEmailOTPFlow(HttpServletRequest request, HttpServletResponse response, String email,
                                      String username, String queryParams,
                                      AuthenticationContext context) throws AuthenticationFailedException {
         Map<String, String> authenticatorProperties = context.getAuthenticatorProperties();


### PR DESCRIPTION
## Purpose
> For having customized emailOTP it is required to over-ride the method. So that any custom authenticators who extends basic emailOTP authenticator can override the behaviour of OTP in the way they want.

