### PR TITLE
add email masking support

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -1731,7 +1731,7 @@ public class EmailOTPAuthenticator extends OpenIDConnectAuthenticator implements
         if ((propertiesFromLocal != null || tenantDomain.equals(EmailOTPAuthenticatorConstants.SUPER_TENANT)) &&
                 parametersMap.containsKey(EmailOTPAuthenticatorConstants.EMAIL_ADDRESS_REGEX)) {
             emailAddressRegex = parametersMap.get(EmailOTPAuthenticatorConstants.EMAIL_ADDRESS_REGEX);
-            if(log.isDebugEnabled()){
+            if (log.isDebugEnabled()) {
                 log.debug("Getting the email address regex from parameters map: " + emailAddressRegex);
             }
         } else if ((context.getProperty(EmailOTPAuthenticatorConstants.EMAIL_ADDRESS_REGEX)) != null) {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -934,7 +934,7 @@ public class EmailOTPAuthenticator extends OpenIDConnectAuthenticator implements
                     }
                     email = email.replaceAll(emailAddressRegex, "*");
                 }
-                else if (log.isDebugEnabled()){
+                else if (log.isDebugEnabled()) {
                     log.debug("Email address regex not set. Showing the complete email address.");
                 }
                 url = url + EmailOTPAuthenticatorConstants.SCREEN_VALUE + email;

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -927,6 +927,10 @@ public class EmailOTPAuthenticator extends OpenIDConnectAuthenticator implements
             }
             String url = getRedirectURL(emailOTPLoginPage, queryParams);
             if (isShowEmailAddressInUIEnable(context, emailOTPParameters)) {
+                String emailAddressRegex = getEmailAddressRegex(context, emailOTPParameters);
+                if (StringUtils.isNotEmpty(emailAddressRegex)) {
+                    email = email.replaceAll(emailAddressRegex, "$1*");
+                }
                 url = url + EmailOTPAuthenticatorConstants.SCREEN_VALUE + email;
             }
             if (context.isRetrying()) {
@@ -1704,6 +1708,27 @@ public class EmailOTPAuthenticator extends OpenIDConnectAuthenticator implements
                     (context.getProperty(EmailOTPAuthenticatorConstants.SHOW_EMAIL_ADDRESS_IN_UI)));
         }
         return isShowEmailAddressInUI;
+    }
+
+    /**
+     * Get the email address regex pattern when we show the email address in UI where the otp is sent.
+     *
+     * @param context       the AuthenticationContext
+     * @param parametersMap the parameter map
+     * @return emailAddressRegex
+     */
+    private String getEmailAddressRegex(AuthenticationContext context, Map<String, String> parametersMap) {
+
+        String emailAddressRegex = null;
+        String tenantDomain = context.getTenantDomain();
+        Object propertiesFromLocal = context.getProperty(IdentityHelperConstants.GET_PROPERTY_FROM_REGISTRY);
+        if ((propertiesFromLocal != null || tenantDomain.equals(EmailOTPAuthenticatorConstants.SUPER_TENANT)) &&
+                parametersMap.containsKey(EmailOTPAuthenticatorConstants.EMAIL_ADDRESS_REGEX)) {
+            emailAddressRegex = parametersMap.get(EmailOTPAuthenticatorConstants.EMAIL_ADDRESS_REGEX);
+        } else if ((context.getProperty(EmailOTPAuthenticatorConstants.EMAIL_ADDRESS_REGEX)) != null) {
+            emailAddressRegex = String.valueOf(context.getProperty(EmailOTPAuthenticatorConstants.EMAIL_ADDRESS_REGEX));
+        }
+        return emailAddressRegex;
     }
 
     private String getAPI(Map<String, String> authenticatorProperties) {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -929,7 +929,7 @@ public class EmailOTPAuthenticator extends OpenIDConnectAuthenticator implements
             if (isShowEmailAddressInUIEnable(context, emailOTPParameters)) {
                 String emailAddressRegex = getEmailAddressRegex(context, emailOTPParameters);
                 if (StringUtils.isNotEmpty(emailAddressRegex)) {
-                    email = email.replaceAll(emailAddressRegex, "$1*");
+                    email = email.replaceAll(emailAddressRegex, "*");
                 }
                 url = url + EmailOTPAuthenticatorConstants.SCREEN_VALUE + email;
             }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -929,7 +929,13 @@ public class EmailOTPAuthenticator extends OpenIDConnectAuthenticator implements
             if (isShowEmailAddressInUIEnable(context, emailOTPParameters)) {
                 String emailAddressRegex = getEmailAddressRegex(context, emailOTPParameters);
                 if (StringUtils.isNotEmpty(emailAddressRegex)) {
+                    if (log.isDebugEnabled()){
+                        log.debug("Email address regex defined. Masking the email address using the regex.");
+                    }
                     email = email.replaceAll(emailAddressRegex, "*");
+                }
+                else if (log.isDebugEnabled()){
+                    log.debug("Email address regex not set. Showing the complete email address.");
                 }
                 url = url + EmailOTPAuthenticatorConstants.SCREEN_VALUE + email;
             }
@@ -1725,8 +1731,14 @@ public class EmailOTPAuthenticator extends OpenIDConnectAuthenticator implements
         if ((propertiesFromLocal != null || tenantDomain.equals(EmailOTPAuthenticatorConstants.SUPER_TENANT)) &&
                 parametersMap.containsKey(EmailOTPAuthenticatorConstants.EMAIL_ADDRESS_REGEX)) {
             emailAddressRegex = parametersMap.get(EmailOTPAuthenticatorConstants.EMAIL_ADDRESS_REGEX);
+            if(log.isDebugEnabled()){
+                log.debug("Getting the email address regex from parameters map: " + emailAddressRegex);
+            }
         } else if ((context.getProperty(EmailOTPAuthenticatorConstants.EMAIL_ADDRESS_REGEX)) != null) {
             emailAddressRegex = String.valueOf(context.getProperty(EmailOTPAuthenticatorConstants.EMAIL_ADDRESS_REGEX));
+            if(log.isDebugEnabled()){
+                log.debug("Getting the email address regex from the context: " + emailAddressRegex);
+            }
         }
         return emailAddressRegex;
     }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -1736,7 +1736,7 @@ public class EmailOTPAuthenticator extends OpenIDConnectAuthenticator implements
             }
         } else if ((context.getProperty(EmailOTPAuthenticatorConstants.EMAIL_ADDRESS_REGEX)) != null) {
             emailAddressRegex = String.valueOf(context.getProperty(EmailOTPAuthenticatorConstants.EMAIL_ADDRESS_REGEX));
-            if(log.isDebugEnabled()){
+            if (log.isDebugEnabled()) {
                 log.debug("Getting the email address regex from the context: " + emailAddressRegex);
             }
         }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
@@ -112,6 +112,7 @@ public class EmailOTPAuthenticatorConstants {
 
     public static final String SCREEN_VALUE = "&screenValue=";
     public static final String SHOW_EMAIL_ADDRESS_IN_UI = "showEmailAddressInUI";
+    public static final String EMAIL_ADDRESS_REGEX = "emailAddressRegex";
     public static final String USE_EVENT_HANDLER_BASED_EMAIL_SENDER = "useEventHandlerBasedEmailSender";
     public static final String TEMPLATE_TYPE = "TEMPLATE_TYPE";
     public static final String EVENT_NAME = "EmailOTP";


### PR DESCRIPTION
## Purpose
Implementation for [issue-7711](https://github.com/wso2/product-is/issues/7711)

This PR provides the above described capability as follows.
1. `EmailAddressRegex` should be enabled.
2. Provide the regex to show the email in UI under `EmailAddressRegex`.

Refer below for the sample configurations configured in deployment.toml file (IS 5.9.0).
````
[authentication.authenticator.email_otp.parameters]
EMAILOTPAuthenticationEndpointURL = "https://localhost:9443/emailotpauthenticationendpoint/emailotp.jsp"
EmailOTPAuthenticationEndpointErrorPage = "https://localhost:9443/emailotpauthenticationendpoint/emailotpError.jsp"
EmailAddressRequestPage = "https://localhost:9443/emailotpauthenticationendpoint/emailAddress.jsp"
usecase = "association"
secondaryUserstore = "primary"
EMAILOTPMandatory = false
sendOTPToFederatedEmailAttribute = false
federatedEmailAttributeKey = "email"
EmailOTPEnableByUserClaim = true
CaptureAndUpdateEmailAddress = true
showEmailAddressInUI = true
useEventHandlerBasedEmailSender = true
emailAddressRegex = '(?&lt;=.{1}).(?=.*@)'
````

With the above implementation and the configurations, the email address will be shown in the UI as follows.
**Enter the code sent to your email ID:`a**********@gmail.com`**
Further, if the regex: `(?&lt;=.)[^@](?=[^@]*?@)|(?:(?&lt;=@.)|(?!^)\\G(?=[^@]*$)).(?=.*\\.)` [1] is used, the same email address will be shown as `a**********@g****.com`.

Basically, it replaces the matched word for the regex with asterisks.
````
email = email.replaceAll(emailAddressRegex, "*");
````

[1] https://stackoverflow.com/questions/43003138/regular-expression-for-email-masking