### PR TITLE
Pass service provider name to the event framework

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
@@ -109,6 +109,7 @@ public class EmailOTPAuthenticatorConstants {
     public static final String EMAIL_ADDRESS_REQ_PAGE = "EmailAddressRequestPage";
     public static final String CODE_MISMATCH = "codeMismatch";
     public static final String BACKUP_CODE = "BackupCode";
+    public static final String PASS_SP_NAME_TO_EVENT = "passSPNameToEvent";
 
     public static final String SCREEN_VALUE = "&screenValue=";
     public static final String SHOW_EMAIL_ADDRESS_IN_UI = "showEmailAddressInUI";


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/9347

With this PR the name of the service provider that the user is trying to log in is added to the event when triggering the event for email OTP. With this improvement, the email template can be customized based on the service provider. 

This improvement can be enabled by adding the following config to the deployment.toml file.
```
[authentication.authenticator.email_otp]
passSPNameToEvent = true
```