### PR TITLE
Save email address after verifying the email address in multi-step authentication

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -335,14 +335,14 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator impl
             String username = authenticatedUser.toFullQualifiedUsername();
             try {
                 String userEmail = getEmailValueForUsername(username, context);
-                if (StringUtils.isEmpty(userEmail)) {
+                if (StringUtils.isBlank(userEmail)) {
                     Object verifiedEmailObject = context.getProperty(EmailOTPAuthenticatorConstants.REQUEST_USER_EMAIL);
                     if (verifiedEmailObject != null) {
                         updateEmailAddressForUsername(context, username);
                     }
                 }
             } catch (EmailOTPException e) {
-                throw new AuthenticationFailedException("Failed to get the email claim when proceed the EmailOTP flow ", e);
+                throw new AuthenticationFailedException("Failed to get the email claim", e);
             }
         }
 

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -291,12 +291,13 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator impl
 
 
         AuthenticatedUser authenticatedUser = getAuthenticatedUser(context);
+        boolean isLocalUser = isLocalUser(context);
         if (authenticatedUser == null) {
             String errorMessage = "Could not find an Authenticated user in the context.";
             throw new AuthenticationFailedException(errorMessage);
         }
 
-        if (isLocalUser(context) && EmailOTPUtils.isAccountLocked(authenticatedUser)) {
+        if (isLocalUser && EmailOTPUtils.isAccountLocked(authenticatedUser)) {
             String errorMessage =
                     String.format("Authentication failed since authenticated user: %s, account is locked.",
                             authenticatedUser);
@@ -328,6 +329,21 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator impl
             succeededAttempt = true;
         } else if (isBackupCodeEnabled(context)) {
             succeededAttempt = validateWithBackUpCodes(context, userToken, authenticatedUser);
+        }
+
+        if (succeededAttempt && isLocalUser) {
+            String username = authenticatedUser.toFullQualifiedUsername();
+            try {
+                String userEmail = getEmailValueForUsername(username, context);
+                if (StringUtils.isEmpty(userEmail)) {
+                    Object verifiedEmailObject = context.getProperty(EmailOTPAuthenticatorConstants.REQUEST_USER_EMAIL);
+                    if (verifiedEmailObject != null) {
+                        updateEmailAddressForUsername(context, username);
+                    }
+                }
+            } catch (EmailOTPException e) {
+                throw new AuthenticationFailedException("Failed to get the email claim when proceed the EmailOTP flow ", e);
+            }
         }
 
         if (!succeededAttempt) {
@@ -624,11 +640,12 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator impl
                 // Email OTP authentication is mandatory and user have Email value in user's profile.
                 email = getEmailValueForUsername(username, context);
                 if (StringUtils.isEmpty(email)) {
-                    if (request.getParameter(EmailOTPAuthenticatorConstants.EMAIL_ADDRESS) == null) {
+                    String requestEmail = request.getParameter(EmailOTPAuthenticatorConstants.EMAIL_ADDRESS);
+                    if (StringUtils.isEmpty(requestEmail)) {
                         redirectToEmailAddressReqPage(response, context, emailOTPParameters, queryParams, username);
                     } else {
-                        updateEmailAddressForUsername(context, request, username);
-                        email = getEmailValueForUsername(username, context);
+                        context.setProperty(EmailOTPAuthenticatorConstants.REQUEST_USER_EMAIL, requestEmail);
+                        email = requestEmail;
                     }
                 }
             }
@@ -645,18 +662,16 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator impl
      * Update email address for specific username when user forgets to update the email address in user's profile.
      *
      * @param context  the AuthenticationContext
-     * @param request  the HttpServletRequest
      * @param username the Username
      * @throws AuthenticationFailedException
      */
-    private void updateEmailAddressForUsername(AuthenticationContext context, HttpServletRequest request,
-                                               String username)
+    private void updateEmailAddressForUsername(AuthenticationContext context, String username)
             throws AuthenticationFailedException {
         String tenantDomain = context.getTenantDomain();
         if (username != null && !context.isRetrying()) {
             Map<String, String> attributes = new HashMap<>();
             attributes.put(EmailOTPAuthenticatorConstants.EMAIL_CLAIM,
-                    request.getParameter(EmailOTPAuthenticatorConstants.EMAIL_ADDRESS));
+                    String.valueOf(context.getProperty(EmailOTPAuthenticatorConstants.REQUEST_USER_EMAIL)));
             updateUserAttribute(MultitenantUtils.getTenantAwareUsername(username), attributes, tenantDomain);
         }
     }
@@ -1402,8 +1417,8 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator impl
                     redirectToEmailAddressReqPage(response, context, emailOTPParameters, queryParams,
                             username);
                 } else {
-                    updateEmailAddressForUsername(context, request, username);
-                    email = getEmailValueForUsername(username, context);
+                    context.setProperty(EmailOTPAuthenticatorConstants.REQUEST_USER_EMAIL, requestEmail);
+                    email = requestEmail;
                 }
             }
         } catch (EmailOTPException | AuthenticationFailedException e) {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -336,13 +336,13 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator impl
             try {
                 String userEmail = getEmailValueForUsername(username, context);
                 if (StringUtils.isBlank(userEmail)) {
-                    Object verifiedEmailObject = context.getProperty(EmailOTPAuthenticatorConstants.REQUEST_USER_EMAIL);
+                    Object verifiedEmailObject = context.getProperty(EmailOTPAuthenticatorConstants.REQUESTED_USER_EMAIL);
                     if (verifiedEmailObject != null) {
                         updateEmailAddressForUsername(context, username);
                     }
                 }
             } catch (EmailOTPException e) {
-                throw new AuthenticationFailedException("Failed to get the email claim", e);
+                throw new AuthenticationFailedException("Failed to get the email claim for user " + username, e);
             }
         }
 
@@ -644,7 +644,7 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator impl
                     if (StringUtils.isEmpty(requestEmail)) {
                         redirectToEmailAddressReqPage(response, context, emailOTPParameters, queryParams, username);
                     } else {
-                        context.setProperty(EmailOTPAuthenticatorConstants.REQUEST_USER_EMAIL, requestEmail);
+                        context.setProperty(EmailOTPAuthenticatorConstants.REQUESTED_USER_EMAIL, requestEmail);
                         email = requestEmail;
                     }
                 }
@@ -671,7 +671,7 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator impl
         if (username != null && !context.isRetrying()) {
             Map<String, String> attributes = new HashMap<>();
             attributes.put(EmailOTPAuthenticatorConstants.EMAIL_CLAIM,
-                    String.valueOf(context.getProperty(EmailOTPAuthenticatorConstants.REQUEST_USER_EMAIL)));
+                    String.valueOf(context.getProperty(EmailOTPAuthenticatorConstants.REQUESTED_USER_EMAIL)));
             updateUserAttribute(MultitenantUtils.getTenantAwareUsername(username), attributes, tenantDomain);
         }
     }
@@ -1417,7 +1417,7 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator impl
                     redirectToEmailAddressReqPage(response, context, emailOTPParameters, queryParams,
                             username);
                 } else {
-                    context.setProperty(EmailOTPAuthenticatorConstants.REQUEST_USER_EMAIL, requestEmail);
+                    context.setProperty(EmailOTPAuthenticatorConstants.REQUESTED_USER_EMAIL, requestEmail);
                     email = requestEmail;
                 }
             }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
@@ -91,7 +91,7 @@ public class EmailOTPAuthenticatorConstants {
     public static final String USER_NAME = "username";
     public static final String AUTHENTICATED_USER = "authenticatedUser";
     public static final String LOCAL_AUTHENTICATOR = "LOCAL";
-    public static final String REQUEST_USER_EMAIL = "userEmail";
+    public static final String REQUESTED_USER_EMAIL = "requestedEmail";
 
     public static final String IS_EMAILOTP_MANDATORY = "EMAILOTPMandatory";
     public static final String EMAILOTP_AUTHENTICATION_ERROR_PAGE_URL = "EmailOTPAuthenticationEndpointErrorPage";

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
@@ -91,6 +91,7 @@ public class EmailOTPAuthenticatorConstants {
     public static final String USER_NAME = "username";
     public static final String AUTHENTICATED_USER = "authenticatedUser";
     public static final String LOCAL_AUTHENTICATOR = "LOCAL";
+    public static final String REQUEST_USER_EMAIL = "userEmail";
 
     public static final String IS_EMAILOTP_MANDATORY = "EMAILOTPMandatory";
     public static final String EMAILOTP_AUTHENTICATION_ERROR_PAGE_URL = "EmailOTPAuthenticationEndpointErrorPage";


### PR DESCRIPTION
In the current implementation when multi step authentication is enabled and if the user has not specify the email address in the profile, it will prompt user to enter email address and then directly saves it. If user enters an
incorrect email there is no way for the user to change it himself. This implementation will only save the email address once it is confirmed with the OTP code sends.

Resolves https://github.com/wso2/product-is/issues/10786
