### PR TITLE
Decouple EmailOTPAuthenticator from extending OpenIDConnectAuthenticator

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -32,6 +32,7 @@ import org.json.JSONObject;
 import org.wso2.carbon.extension.identity.helper.FederatedAuthenticatorUtil;
 import org.wso2.carbon.extension.identity.helper.IdentityHelperConstants;
 import org.wso2.carbon.extension.identity.helper.util.IdentityHelperUtil;
+import org.wso2.carbon.identity.application.authentication.framework.AbstractApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorFlowStatus;
 import org.wso2.carbon.identity.application.authentication.framework.FederatedApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.LocalApplicationAuthenticator;
@@ -44,7 +45,6 @@ import org.wso2.carbon.identity.application.authentication.framework.exception.L
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.authenticator.oidc.OIDCAuthenticatorConstants;
-import org.wso2.carbon.identity.application.authenticator.oidc.OpenIDConnectAuthenticator;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.authenticator.emailotp.config.EmailOTPUtils;
@@ -96,7 +96,7 @@ import static org.wso2.carbon.identity.authenticator.emailotp.EmailOTPAuthentica
 /**
  * Authenticator of EmailOTP.
  */
-public class EmailOTPAuthenticator extends OpenIDConnectAuthenticator implements FederatedApplicationAuthenticator {
+public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator implements FederatedApplicationAuthenticator {
 
     private static final Log log = LogFactory.getLog(EmailOTPAuthenticator.class);
 
@@ -2006,9 +2006,9 @@ public class EmailOTPAuthenticator extends OpenIDConnectAuthenticator implements
     }
 
     /**
+     * @deprecated Since EmailOTPAuthenticator not extending OpenIDConnectAuthenticator.
      * Check ID token in EmailOTP OAuth.
      */
-    @Override
     protected boolean requiredIDToken(Map<String, String> authenticatorProperties) {
         return false;
     }


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/product-is/issues/10782

Description
Since these 2 authenticators serve 2 different purposes (OpenIDConnectAuthenticator for identity federation and Email OTP for MFA),  we need to decouple them