### PR TITLE
Enable tenant qualified URL support

### DIFF
--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -69,7 +69,6 @@
                             org.wso2.carbon.identity.event.event; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.event.services; version="${carbon.identity.package.import.version.range}",
                             org.apache.oltu.oauth2.*; version="${oltu.package.import.version.range}",
-                            org.wso2.carbon.identity.application.authenticator.oidc; version="${identity.outbound.auth.oidc.import.version.range}",
                             org.wso2.carbon.identity.handler.event.account.lock.service;
                             version="${carbon.identity.account.lock.handler.imp.pkg.version.range}",
                             org.wso2.carbon.identity.handler.event.account.lock.exception;

--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -158,10 +158,6 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
-            <artifactId>org.wso2.carbon.identity.event</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
         </dependency>
         <dependency>
@@ -212,11 +208,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-core</artifactId>
             <scope>test</scope>
@@ -227,8 +218,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.identity.outbound.auth.oidc</groupId>
-            <artifactId>org.wso2.carbon.identity.application.authenticator.oidc</artifactId>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
@@ -39,6 +39,8 @@ public class EmailOTPAuthenticatorConstants {
     public static final String API_GMAIL = "Gmail";
     public static final String API_SENDGRID = "Sendgrid";
 
+    public static final String CLIENT_ID = "ClientId";
+    public static final String CLIENT_SECRET = "ClientSecret";
     public static final String CODE = "OTPCode";
     public static final String EMAILOTP_TOKEN_ENDPOINT = "TokenEndpoint";
     public static final String REFRESH_TOKEN = "RefreshToken";
@@ -59,7 +61,10 @@ public class EmailOTPAuthenticatorConstants {
     public static final String MAIL_API_KEY = "<API_KEY>";
 
     public static final String LOGIN_PAGE = "authenticationendpoint/login.do";
+    public static final String EMAIL_CAPTURE_PAGE = "emailotpauthenticationendpoint/emailAddress.jsp";
     public static final String EMAILOTP_PAGE = "emailotpauthenticationendpoint/emailotp.jsp";
+    public static final String ERROR_PAGE = "emailotpauthenticationendpoint/emailotpError.jsp";
+
     public static final String EMAILOTP_AUTHENTICATION_ENDPOINT_URL = "EMAILOTPAuthenticationEndpointURL";
     public static final String RETRY_PARAMS = "&authFailure=true&authFailureMsg=authentication.fail.message";
     public static final String EMAIL_CLAIM = "http://wso2.org/claims/emailaddress";
@@ -101,7 +106,6 @@ public class EmailOTPAuthenticatorConstants {
     public static final String EMAILOTP_AUTHENTICATION_ERROR_PAGE_URL = "EmailOTPAuthenticationEndpointErrorPage";
     public static final String ERROR_EMAILOTP_DISABLE = "&authFailure=true&authFailureMsg=emailotp.disable";
     public static final String SEND_OTP_DIRECTLY_DISABLE = "&authFailure=true&authFailureMsg=directly.send.otp.disable";
-    public static final String ERROR_PAGE = "emailotpauthenticationendpoint/emailotpError.jsp";
     public static final String BASIC = "basic";
     public static final String FEDERETOR = "federator";
     public static final String SEND_OTP_TO_FEDERATED_EMAIL_ATTRIBUTE = "sendOTPToFederatedEmailAttribute";

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
@@ -61,7 +61,7 @@ public class EmailOTPAuthenticatorConstants {
     public static final String MAIL_API_KEY = "<API_KEY>";
 
     public static final String LOGIN_PAGE = "authenticationendpoint/login.do";
-    public static final String EMAIL_CAPTURE_PAGE = "emailotpauthenticationendpoint/emailAddress.jsp";
+    public static final String EMAIL_ADDRESS_CAPTURE_PAGE = "emailotpauthenticationendpoint/emailAddress.jsp";
     public static final String EMAILOTP_PAGE = "emailotpauthenticationendpoint/emailotp.jsp";
     public static final String ERROR_PAGE = "emailotpauthenticationendpoint/emailotpError.jsp";
 

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPUrlUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPUrlUtil.java
@@ -28,7 +28,7 @@ import java.util.Map;
 
 import static org.wso2.carbon.identity.authenticator.emailotp.EmailOTPAuthenticatorConstants.EMAILOTP_PAGE;
 import static org.wso2.carbon.identity.authenticator.emailotp.EmailOTPAuthenticatorConstants.EMAIL_ADDRESS_REQ_PAGE;
-import static org.wso2.carbon.identity.authenticator.emailotp.EmailOTPAuthenticatorConstants.EMAIL_CAPTURE_PAGE;
+import static org.wso2.carbon.identity.authenticator.emailotp.EmailOTPAuthenticatorConstants.EMAIL_ADDRESS_CAPTURE_PAGE;
 import static org.wso2.carbon.identity.authenticator.emailotp.EmailOTPAuthenticatorConstants.ERROR_PAGE;
 
 /**
@@ -47,7 +47,7 @@ public class EmailOTPUrlUtil {
 
         try {
             if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
-                return ServiceURLBuilder.create().addPath(EMAIL_CAPTURE_PAGE).build().getAbsolutePublicURL();
+                return ServiceURLBuilder.create().addPath(EMAIL_ADDRESS_CAPTURE_PAGE).build().getAbsolutePublicURL();
             } else {
                 return getEmailAddressRequestPage(context, authenticationConfigs);
             }
@@ -101,7 +101,7 @@ public class EmailOTPUrlUtil {
         } else if ((context.getProperty(EMAIL_ADDRESS_REQ_PAGE)) != null) {
             emailAddressReqPage = String.valueOf(context.getProperty(EMAIL_ADDRESS_REQ_PAGE));
         } else {
-            emailAddressReqPage = ServiceURLBuilder.create().addPath(EMAIL_CAPTURE_PAGE).build().getAbsolutePublicURL();
+            emailAddressReqPage = ServiceURLBuilder.create().addPath(EMAIL_ADDRESS_CAPTURE_PAGE).build().getAbsolutePublicURL();
         }
         return emailAddressReqPage;
     }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPUrlUtil.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPUrlUtil.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.identity.authenticator.emailotp;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.extension.identity.helper.IdentityHelperConstants;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+
+import java.util.Map;
+
+import static org.wso2.carbon.identity.authenticator.emailotp.EmailOTPAuthenticatorConstants.EMAILOTP_PAGE;
+import static org.wso2.carbon.identity.authenticator.emailotp.EmailOTPAuthenticatorConstants.EMAIL_ADDRESS_REQ_PAGE;
+import static org.wso2.carbon.identity.authenticator.emailotp.EmailOTPAuthenticatorConstants.EMAIL_CAPTURE_PAGE;
+import static org.wso2.carbon.identity.authenticator.emailotp.EmailOTPAuthenticatorConstants.ERROR_PAGE;
+
+/**
+ * Utility for building URLs related to email otp authentication flow.
+ */
+public class EmailOTPUrlUtil {
+
+    private static final Log log = LogFactory.getLog(EmailOTPUrlUtil.class);
+
+    private EmailOTPUrlUtil() {
+
+    }
+
+    public static String getRequestEmailPageUrl(AuthenticationContext context, Map<String, String> authenticationConfigs)
+            throws AuthenticationFailedException {
+
+        try {
+            if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+                return ServiceURLBuilder.create().addPath(EMAIL_CAPTURE_PAGE).build().getAbsolutePublicURL();
+            } else {
+                return getEmailAddressRequestPage(context, authenticationConfigs);
+            }
+        } catch (URLBuilderException e) {
+            throw new AuthenticationFailedException("Error building email request page URL.", e);
+        }
+    }
+
+    public static String getEmailOTPLoginPageUrl(AuthenticationContext context, Map<String, String> authenticationConfigs)
+            throws AuthenticationFailedException {
+
+        try {
+            if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+                return ServiceURLBuilder.create().addPath(EMAILOTP_PAGE).build().getAbsolutePublicURL();
+            } else {
+                return getEmailOTPLoginPage(context, authenticationConfigs);
+            }
+        } catch (URLBuilderException e) {
+            throw new AuthenticationFailedException("Error building email OTP login page URL.", e);
+        }
+    }
+
+    public static String getEmailOTPErrorPageUrl(AuthenticationContext context, Map<String, String> authenticationConfigs)
+            throws AuthenticationFailedException {
+        try {
+            if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+                return ServiceURLBuilder.create().addPath(ERROR_PAGE).build().getAbsolutePublicURL();
+            } else {
+                return getEmailOTPErrorPage(context, authenticationConfigs);
+            }
+        } catch (URLBuilderException e) {
+            throw new AuthenticationFailedException("Error building email OTP error page URL.", e);
+        }
+    }
+
+    /**
+     * Get the email address request page url from the application-authentication.xml file.
+     *
+     * @param context the AuthenticationContext
+     * @return email address request page
+     */
+    private static String getEmailAddressRequestPage(AuthenticationContext context,
+                                                     Map<String, String> parametersMap) throws URLBuilderException {
+
+        String emailAddressReqPage;
+        String tenantDomain = context.getTenantDomain();
+        Object propertiesFromLocal = context.getProperty(IdentityHelperConstants.GET_PROPERTY_FROM_REGISTRY);
+        if ((propertiesFromLocal != null || EmailOTPAuthenticatorConstants.SUPER_TENANT.equals(tenantDomain)) &&
+                parametersMap.containsKey(EMAIL_ADDRESS_REQ_PAGE)) {
+            emailAddressReqPage = parametersMap.get(EMAIL_ADDRESS_REQ_PAGE);
+        } else if ((context.getProperty(EMAIL_ADDRESS_REQ_PAGE)) != null) {
+            emailAddressReqPage = String.valueOf(context.getProperty(EMAIL_ADDRESS_REQ_PAGE));
+        } else {
+            emailAddressReqPage = ServiceURLBuilder.create().addPath(EMAIL_CAPTURE_PAGE).build().getAbsolutePublicURL();
+        }
+        return emailAddressReqPage;
+    }
+
+    /**
+     * Get ErrorPage for Gmail APIs
+     */
+    private static String getEmailOTPErrorPage(AuthenticationContext context,
+                                               Map<String, String> parametersMap) throws URLBuilderException {
+
+        String errorPage;
+        String tenantDomain = context.getTenantDomain();
+        Object propertiesFromLocal = context.getProperty(IdentityHelperConstants.GET_PROPERTY_FROM_REGISTRY);
+        if ((propertiesFromLocal != null || EmailOTPAuthenticatorConstants.SUPER_TENANT.equals(tenantDomain)) &&
+                parametersMap.containsKey(EmailOTPAuthenticatorConstants.EMAILOTP_AUTHENTICATION_ERROR_PAGE_URL)) {
+            errorPage = parametersMap.get(EmailOTPAuthenticatorConstants.EMAILOTP_AUTHENTICATION_ERROR_PAGE_URL);
+        } else if ((context.getProperty(EmailOTPAuthenticatorConstants.EMAILOTP_AUTHENTICATION_ERROR_PAGE_URL)) != null) {
+            errorPage = String.valueOf(context.getProperty
+                    (EmailOTPAuthenticatorConstants.EMAILOTP_AUTHENTICATION_ERROR_PAGE_URL));
+        } else {
+            errorPage = ServiceURLBuilder.create().addPath(ERROR_PAGE).build().getAbsolutePublicURL();
+        }
+        return errorPage;
+    }
+
+    /**
+     * Get LoginPage for Gmail APIs
+     */
+    private static String getEmailOTPLoginPage(AuthenticationContext context,
+                                               Map<String, String> parametersMap) throws URLBuilderException {
+        String loginPage;
+        String tenantDomain = context.getTenantDomain();
+        Object propertiesFromLocal = context.getProperty(IdentityHelperConstants.GET_PROPERTY_FROM_REGISTRY);
+        if ((propertiesFromLocal != null || EmailOTPAuthenticatorConstants.SUPER_TENANT.equals(tenantDomain)) &&
+                parametersMap.containsKey(EmailOTPAuthenticatorConstants.EMAILOTP_AUTHENTICATION_ENDPOINT_URL)) {
+            loginPage = parametersMap.get(EmailOTPAuthenticatorConstants.EMAILOTP_AUTHENTICATION_ENDPOINT_URL);
+        } else if ((context.getProperty(EmailOTPAuthenticatorConstants.EMAILOTP_AUTHENTICATION_ENDPOINT_URL)) != null) {
+            loginPage = String.valueOf(context.getProperty
+                    (EmailOTPAuthenticatorConstants.EMAILOTP_AUTHENTICATION_ENDPOINT_URL));
+        } else {
+            loginPage = ServiceURLBuilder.create().addPath(EMAILOTP_PAGE).build().getAbsolutePublicURL();
+        }
+        return loginPage;
+    }
+}

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorTestConstants.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorTestConstants.java
@@ -16,7 +16,7 @@
  *  under the License.
  *
  */
-package org.wso2.carbon.identity.application.authenticator.emailotp;
+package org.wso2.carbon.identity.authenticator.emailotp;
 
 public class EmailOTPAuthenticatorTestConstants {
     public static String EMAIL_ADDRESS = "abc@gmail.com";

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOtpURLUtilTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOtpURLUtilTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.identity.authenticator.emailotp;
+
+import org.apache.commons.lang.StringUtils;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
+import org.wso2.carbon.identity.core.ServiceURL;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+
+@PrepareForTest({IdentityTenantUtil.class, ServiceURLBuilder.class})
+public class EmailOtpURLUtilTest extends PowerMockTestCase {
+
+    @BeforeMethod
+    public void setUp() throws URLBuilderException {
+
+        mockServiceURLBuilder();
+    }
+
+    @DataProvider(name = "requestEmailPageDataProvider")
+    public static Object[][] getRequestEmailPageURLData() {
+
+        return new Object[][]{
+                // Tenant null is thread local context
+                {false, null, "https://localhost:9443/emailotpauthenticationendpoint/emailAddress.jsp"},
+                {true, null, "https://localhost:9443/t/null/emailotpauthenticationendpoint/emailAddress.jsp"},
+
+                // Super tenant
+                {false, "carbon.super", "https://localhost:9443/emailotpauthenticationendpoint/emailAddress.jsp"},
+                {true, "carbon.super", "https://localhost:9443/emailotpauthenticationendpoint/emailAddress.jsp"},
+
+                // Tenant
+                {false, "wso2.com", "https://localhost:9443/emailotpauthenticationendpoint/emailAddress.jsp"},
+                {true, "wso2.com", "https://localhost:9443/t/wso2.com/emailotpauthenticationendpoint/emailAddress.jsp"},
+        };
+    }
+
+    @Test(dataProvider = "requestEmailPageDataProvider")
+    public void testGetRequestEmailPage(boolean isTenantQualifiedURLEnabled,
+                                        String tenantDomainInThreadLocal,
+                                        String expectedURL) throws AuthenticationFailedException {
+
+        mockStatic(IdentityTenantUtil.class);
+        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifiedURLEnabled);
+        when(IdentityTenantUtil.getTenantDomainFromContext()).thenReturn(tenantDomainInThreadLocal);
+
+        assertEquals(EmailOTPUrlUtil.getRequestEmailPageUrl(new AuthenticationContext(), new HashMap<>()), expectedURL);
+    }
+
+    @DataProvider(name = "emailOTPLoginPageURLDataProvider")
+    public static Object[][] getEmailOTPLoginPageURLData() {
+
+        return new Object[][]{
+                // Tenant null is thread local context
+                {false, null, "https://localhost:9443/emailotpauthenticationendpoint/emailotp.jsp"},
+                {true, null, "https://localhost:9443/t/null/emailotpauthenticationendpoint/emailotp.jsp"},
+
+                // Super tenant
+                {false, "carbon.super", "https://localhost:9443/emailotpauthenticationendpoint/emailotp.jsp"},
+                {true, "carbon.super", "https://localhost:9443/emailotpauthenticationendpoint/emailotp.jsp"},
+
+                // Tenant
+                {false, "wso2.com", "https://localhost:9443/emailotpauthenticationendpoint/emailotp.jsp"},
+                {true, "wso2.com", "https://localhost:9443/t/wso2.com/emailotpauthenticationendpoint/emailotp.jsp"},
+        };
+    }
+
+    @Test(dataProvider = "emailOTPLoginPageURLDataProvider")
+    public void testGetLoginPage(boolean isTenantQualifiedURLEnabled,
+                                 String tenantDomainInThreadLocal,
+                                 String expectedURL) throws AuthenticationFailedException {
+
+        mockStatic(IdentityTenantUtil.class);
+        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifiedURLEnabled);
+        when(IdentityTenantUtil.getTenantDomainFromContext()).thenReturn(tenantDomainInThreadLocal);
+
+        assertEquals(EmailOTPUrlUtil.getEmailOTPLoginPageUrl(new AuthenticationContext(), new HashMap<>()), expectedURL);
+    }
+
+    @DataProvider(name = "emailOTPErrorPageURLDataProvider")
+    public static Object[][] getEmailOTPErrorPagePageURLData() {
+
+        return new Object[][]{
+                // Tenant null is thread local context
+                {false, null, "https://localhost:9443/emailotpauthenticationendpoint/emailotpError.jsp"},
+                {true, null, "https://localhost:9443/t/null/emailotpauthenticationendpoint/emailotpError.jsp"},
+
+                // Super tenant
+                {false, "carbon.super", "https://localhost:9443/emailotpauthenticationendpoint/emailotpError.jsp"},
+                {true, "carbon.super", "https://localhost:9443/emailotpauthenticationendpoint/emailotpError.jsp"},
+
+                // Tenant
+                {false, "wso2.com", "https://localhost:9443/emailotpauthenticationendpoint/emailotpError.jsp"},
+                {true, "wso2.com", "https://localhost:9443/t/wso2.com/emailotpauthenticationendpoint/emailotpError.jsp"},
+        };
+    }
+
+    @Test(dataProvider = "emailOTPErrorPageURLDataProvider")
+    public void testGetErrorPage(boolean isTenantQualifiedURLEnabled,
+                                 String tenantDomainInThreadLocal,
+                                 String expectedURL) throws AuthenticationFailedException {
+
+        mockStatic(IdentityTenantUtil.class);
+        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(isTenantQualifiedURLEnabled);
+        when(IdentityTenantUtil.getTenantDomainFromContext()).thenReturn(tenantDomainInThreadLocal);
+
+        assertEquals(EmailOTPUrlUtil.getEmailOTPErrorPageUrl(new AuthenticationContext(), new HashMap<>()), expectedURL);
+    }
+
+    @Test(description = "Tests getting email request page URL in non tenant qualified URL mode.")
+    public void testGetEmailAddressRequestPage() throws Exception {
+
+        String reqPage = "emailotpEndpoint/reqPage.jsp";
+
+        mockStatic(IdentityTenantUtil.class);
+        when(IdentityTenantUtil.isTenantQualifiedUrlsEnabled()).thenReturn(false);
+
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put(EmailOTPAuthenticatorConstants.EMAIL_ADDRESS_REQ_PAGE, reqPage);
+
+        AuthenticationContext context = new AuthenticationContext();
+        context.setTenantDomain(EmailOTPAuthenticatorTestConstants.TENANT_DOMAIN);
+        context.setProperty(EmailOTPAuthenticatorConstants.EMAIL_ADDRESS_REQ_PAGE, reqPage);
+        Assert.assertEquals(EmailOTPUrlUtil.getRequestEmailPageUrl(context, parameters), reqPage);
+
+        //get from parameters
+        context.setTenantDomain(EmailOTPAuthenticatorConstants.SUPER_TENANT);
+        Assert.assertEquals(EmailOTPUrlUtil.getRequestEmailPageUrl(context, parameters), reqPage);
+    }
+
+    private void mockServiceURLBuilder() throws URLBuilderException {
+
+        ServiceURLBuilder builder = new ServiceURLBuilder() {
+
+            String path = "";
+
+            @Override
+            public ServiceURLBuilder addPath(String... strings) {
+
+                Arrays.stream(strings).forEach(x -> {
+                    path += "/" + x;
+                });
+                return this;
+            }
+
+            @Override
+            public ServiceURLBuilder addParameter(String s, String s1) {
+
+                return this;
+            }
+
+            @Override
+            public ServiceURLBuilder setFragment(String s) {
+
+                return this;
+            }
+
+            @Override
+            public ServiceURLBuilder addFragmentParameter(String s, String s1) {
+
+                return this;
+            }
+
+            @Override
+            public ServiceURL build() throws URLBuilderException {
+
+                ServiceURL serviceURL = mock(ServiceURL.class);
+                when(serviceURL.getRelativePublicURL()).thenReturn(path);
+                when(serviceURL.getRelativeInternalURL()).thenReturn(path);
+
+                String tenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
+                if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()
+                        && !StringUtils.equals(tenantDomain, SUPER_TENANT_DOMAIN_NAME)) {
+                    when(serviceURL.getAbsolutePublicURL())
+                            .thenReturn("https://localhost:9443/t/" + tenantDomain + path);
+                } else {
+                    when(serviceURL.getAbsolutePublicURL()).thenReturn("https://localhost:9443" + path);
+                }
+                return serviceURL;
+            }
+        };
+
+        mockStatic(ServiceURLBuilder.class);
+        when(ServiceURLBuilder.create()).thenReturn(builder);
+    }
+}

--- a/component/authenticator/src/test/resources/log4j.properties
+++ b/component/authenticator/src/test/resources/log4j.properties
@@ -1,0 +1,8 @@
+# Root logger option
+log4j.rootLogger=DEBUG, stdout
+
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %c{1}:%L - %m%n

--- a/component/authenticator/src/test/resources/testng.xml
+++ b/component/authenticator/src/test/resources/testng.xml
@@ -21,7 +21,8 @@
 
     <test name="EmailOTP-Authenticator-Unit-Tests">
         <classes>
-            <class name="org.wso2.carbon.identity.application.authenticator.emailotp.EmailOTPAuthenticatorTest" />
+            <class name="org.wso2.carbon.identity.authenticator.emailotp.EmailOTPAuthenticatorTest" />
+            <class name="org.wso2.carbon.identity.authenticator.emailotp.EmailOtpURLUtilTest" />
         </classes>
     </test>
 </suite>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
                 <groupId>log4j</groupId>
                 <artifactId>log4j</artifactId>
                 <version>${log4j.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
@@ -134,12 +135,32 @@
                 <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.core</artifactId>
                 <version>${carbon.identity.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.ops4j.pax.logging</groupId>
+                        <artifactId>pax-logging-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.ops4j.pax.logging</groupId>
+                        <artifactId>pax-logging-log4j2</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
                 <version>${carbon.identity.version}</version>
                 <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.ops4j.pax.logging</groupId>
+                        <artifactId>pax-logging-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.ops4j.pax.logging</groupId>
+                        <artifactId>pax-logging-log4j2</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
@@ -178,12 +199,6 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon.identity.outbound.auth.oidc</groupId>
-                <artifactId>org.wso2.carbon.identity.application.authenticator.oidc</artifactId>
-                <version>${org.wso2.carbon.identity.outbound.auth.oidc}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>org.wso2.carbon.ui</artifactId>
                 <version>${carbon.kernel.version}</version>
@@ -206,17 +221,55 @@
                 <artifactId>org.wso2.carbon.extension.identity.helper</artifactId>
                 <version>${identity.extension.utils}</version>
                 <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>jcl-over-slf4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>log4j-over-slf4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-jdk14</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.event</artifactId>
                 <version>${carbon.identity.event.version}</version>
                 <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.ops4j.pax.logging</groupId>
+                        <artifactId>pax-logging-log4j2</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.ops4j.pax.logging</groupId>
+                        <artifactId>pax-logging-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.event.handler.accountlock</groupId>
                 <artifactId>org.wso2.carbon.identity.handler.event.account.lock</artifactId>
                 <version>${carbon.identity.account.lock.handler.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>jcl-over-slf4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>log4j-over-slf4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-jdk14</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -463,7 +516,7 @@
     </distributionManagement>
 
     <properties>
-        <carbon.identity.version>5.12.335</carbon.identity.version>
+        <carbon.identity.version>5.18.215</carbon.identity.version>
         <carbon.identity.event.version>5.18.209</carbon.identity.event.version>
         <commons-logging.version>4.4.3</commons-logging.version>
         <carbon.kernel.version>4.6.1</carbon.kernel.version>
@@ -482,12 +535,8 @@
         <identity.extension.utils>1.0.8</identity.extension.utils>
         <identity.extension.utils.import.version.range>[1.0.8,2.0.0)
         </identity.extension.utils.import.version.range>
-        <log4j.version>1.2.13</log4j.version>
-        <rampart.wso2.version>1.6.1.wso2v17</rampart.wso2.version>
-        <rampart.wso2.osgi.version.range>[1.6.1,2.0.0)</rampart.wso2.osgi.version.range>
-        <rampart.mar.version>1.6.1.wso2v17</rampart.mar.version>
+        <log4j.version>1.2.16</log4j.version>
         <org.wso2.carbon.identity.association.account>5.1.5</org.wso2.carbon.identity.association.account>
-        <org.wso2.carbon.identity.outbound.auth.oidc>5.1.20</org.wso2.carbon.identity.outbound.auth.oidc>
         <identity.outbound.auth.oidc.import.version.range>[5.1.20,6.0.0)</identity.outbound.auth.oidc.import.version.range>
         <carbon.identity.account.lock.handler.version>1.1.12</carbon.identity.account.lock.handler.version>
         <carbon.identity.account.lock.handler.imp.pkg.version.range>[1.1.12, 2.0.0)


### PR DESCRIPTION
Improvement added with this PR
* Qualifies the redirect URL when the tenant qualified URLs feature is enabled
* Fallback to default URLs in the server, when no configuration is present for redirect page URLs

Part of fixing https://github.com/wso2/product-is/issues/10931