### PR TITLE
Avoid triggering the event when email OTP is disabled

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -2610,10 +2610,15 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator impl
     private void publishPostEmailOTPGeneratedEvent(HttpServletRequest request, AuthenticationContext context)
             throws AuthenticationFailedException {
 
-        Map<String, Object> eventProperties = new HashMap<>();
-        eventProperties.put(IdentityEventConstants.EventProperty.CORRELATION_ID, context.getCallerSessionKey());
         AuthenticatedUser authenticatedUser = (AuthenticatedUser) context.getProperty(EmailOTPAuthenticatorConstants
                 .AUTHENTICATED_USER);
+        Map<String, String> emailOTPParameters = getAuthenticatorConfig().getParameterMap();
+        if (isEmailOTPDisableForUser(authenticatedUser.getUserName(), context, emailOTPParameters)) {
+            // Email OTP is disabled for the user. Hence not going to trigger the event.
+            return;
+        }
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(IdentityEventConstants.EventProperty.CORRELATION_ID, context.getCallerSessionKey());
         eventProperties.put(IdentityEventConstants.EventProperty.USER_NAME, authenticatedUser.getUserName());
         eventProperties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, context.getTenantDomain());
         eventProperties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, authenticatedUser


### PR DESCRIPTION
## Purpose
This PR changes will avoid trigger the POST_GENERATE_EMAIL_OTP event when email OTP is disabled for a user.
Resolves: https://github.com/wso2/product-is/issues/11132