### PR TITLE
Check email OTP disabled for a user by authenticated subject identifier

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -2613,7 +2613,8 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator impl
         AuthenticatedUser authenticatedUser = (AuthenticatedUser) context.getProperty(EmailOTPAuthenticatorConstants
                 .AUTHENTICATED_USER);
         Map<String, String> emailOTPParameters = getAuthenticatorConfig().getParameterMap();
-        if (isEmailOTPDisableForUser(authenticatedUser.getUserName(), context, emailOTPParameters)) {
+        if (isEmailOTPDisableForUser(authenticatedUser.getAuthenticatedSubjectIdentifier(),
+                context, emailOTPParameters)) {
             // Email OTP is disabled for the user. Hence not going to trigger the event.
             return;
         }


### PR DESCRIPTION
## Purpose
With this PR changes it will check whether the email OTP is disabled for a user by authenticated subject identifier, since using the get username by the authenticated user does not give the correct result for the tenant users.

Related PR: https://github.com/wso2-extensions/identity-outbound-auth-email-otp/pull/105