### PR TITLE
Avoid storing references of authenticated user from previous subject steps

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -90,7 +90,6 @@ import java.net.URLConnection;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -525,7 +524,9 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator impl
         for (StepConfig stepConfig : stepConfigMap.values()) {
             AuthenticatedUser authenticatedUserInStepConfig = stepConfig.getAuthenticatedUser();
             if (stepConfig.isSubjectAttributeStep() && authenticatedUserInStepConfig != null) {
-                authenticatedUser = stepConfig.getAuthenticatedUser();
+                // Make a copy of the user from the subject attribute step as we might modify this within
+                // the authenticator.
+                authenticatedUser = new AuthenticatedUser(authenticatedUserInStepConfig);
                 break;
             }
         }


### PR DESCRIPTION
Currently the email OTP authenticator fetches the authenticated user references from the previous subject step and sets that as the subject of it's own step upon authentication completion.

Having the reference from another step is not safe as we see later at Framework level, the subject in the step is modifed based on the authenticator type. Refer code [segment](https://github.com/wso2/carbon-identity-framework/blob/96185e516cbec32b893268508837a83a1cbeba6a/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/AbstractApplicationAuthenticator.java#L179-L190)

This is a separate issue that needs to be handled