### PR TITLE
Version upgrade for newly created 2.0.12.1.xx

### DIFF
--- a/component/authentication-endpoint/pom.xml
+++ b/component/authentication-endpoint/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.emailotp</groupId>
         <artifactId>identity-outbound-auth-email-otp</artifactId>
-        <version>2.0.12.1</version>
+        <version>2.0.12.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>org.wso2.carbon.extension.identity.authenticator.emailotp.endpoint</artifactId>

--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.emailotp</groupId>
         <artifactId>identity-outbound-auth-email-otp</artifactId>
-        <version>2.0.12.1</version>
+        <version>2.0.12.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>org.wso2.carbon.extension.identity.authenticator.emailotp.connector</artifactId>

--- a/feature/pom.xml
+++ b/feature/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.emailotp</groupId>
         <artifactId>identity-outbound-auth-email-otp</artifactId>
-        <version>2.0.12.1</version>
+        <version>2.0.12.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>org.wso2.carbon.extension.identity.authenticator.emailotp.feature</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.emailotp</groupId>
     <artifactId>identity-outbound-auth-email-otp</artifactId>
-    <version>2.0.12.1</version>
+    <version>2.0.12.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>WSO2 Carbon Extension - EmailOTP Pom</name>
     <url>http://wso2.org</url>


### PR DESCRIPTION
**Reason for the branch creation**

This 2.0.12.1.x branch is created to release the email OTP connector versions which are compatible with the IS-5.2.0. At the branch creation point, the existing version in the IS-5.2.0 was 2.0.12.1. Hence it was decided to create a branch from 2.0.12.1 tag. Currently existing 2.0.12.x branch has added a dependency for `org.wso2.carbon.identity.event.handler.accountlock` which is not supported by IS-5.2.0. Hence for IS-5.2.0, it can't use the latest release from the 2.0.12.x. Therefore considering these reasons 2.0.12.1.x branch was created.