### PR TITLE
[5.2.0] Support account locking for email otp

### DIFF
--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -96,5 +96,10 @@
             <artifactId>org.wso2.carbon.extension.identity.helper</artifactId>
             <version>${identity.extension.utils}</version>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity</groupId>
+            <artifactId>org.wso2.carbon.identity.mgt</artifactId>
+            <version>${carbon.identity.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -24,6 +24,7 @@ import org.apache.axis2.AxisFault;
 import org.apache.axis2.context.ConfigurationContext;
 import org.apache.axis2.context.ConfigurationContextFactory;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.json.JSONObject;
@@ -45,8 +46,10 @@ import org.wso2.carbon.identity.application.authenticator.oidc.OIDCAuthenticator
 import org.wso2.carbon.identity.application.authenticator.oidc.OpenIDConnectAuthenticator;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.Property;
+import org.wso2.carbon.identity.authenticator.emailotp.config.EmailOTPUtils;
 import org.wso2.carbon.identity.authenticator.emailotp.exception.EmailOTPException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.mgt.IdentityMgtConfigException;
 import org.wso2.carbon.identity.mgt.IdentityMgtServiceException;
 import org.wso2.carbon.identity.mgt.NotificationSender;
@@ -54,6 +57,7 @@ import org.wso2.carbon.identity.mgt.NotificationSendingModule;
 import org.wso2.carbon.identity.mgt.config.Config;
 import org.wso2.carbon.identity.mgt.config.ConfigBuilder;
 import org.wso2.carbon.identity.mgt.config.ConfigType;
+import org.wso2.carbon.identity.mgt.IdentityMgtConfig;
 import org.wso2.carbon.identity.mgt.config.StorageType;
 import org.wso2.carbon.identity.mgt.dto.NotificationDataDTO;
 import org.wso2.carbon.identity.mgt.mail.DefaultEmailSendingModule;
@@ -63,6 +67,7 @@ import org.wso2.carbon.identity.mgt.mail.NotificationData;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.api.UserStoreManager;
+import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
@@ -218,6 +223,22 @@ public class EmailOTPAuthenticator extends OpenIDConnectAuthenticator implements
     @Override
     protected void processAuthenticationResponse(HttpServletRequest request, HttpServletResponse response,
                                                  AuthenticationContext context) throws AuthenticationFailedException {
+
+        AuthenticatedUser authenticatedUser = getAuthenticatedUser(context);
+        if (authenticatedUser == null) {
+            String errorMessage = "Could not find an Authenticated user in the context.";
+            throw new AuthenticationFailedException(errorMessage);
+        }
+
+        if (isLocalUser(context) && EmailOTPUtils.isAccountLocked(authenticatedUser)) {
+            String errorMessage =
+                    String.format("Authentication failed since authenticated user: %s, account is locked.",
+                            authenticatedUser);
+            if (log.isDebugEnabled()) {
+                log.debug(errorMessage);
+            }
+            throw new AuthenticationFailedException(errorMessage);
+        }
         if (StringUtils.isEmpty(request.getParameter(EmailOTPAuthenticatorConstants.CODE))) {
             if (log.isDebugEnabled()) {
                 log.debug("One time password cannot be null");
@@ -241,8 +262,11 @@ public class EmailOTPAuthenticator extends OpenIDConnectAuthenticator implements
             if (log.isDebugEnabled()) {
                 log.debug("Given otp code is mismatch");
             }
+            handleOtpVerificationFail(context);
             throw new AuthenticationFailedException("Code mismatch");
         }
+        // It reached here means the authentication was successful.
+        resetOtpFailedAttempts(context);
     }
 
     /**
@@ -1556,5 +1580,206 @@ public class EmailOTPAuthenticator extends OpenIDConnectAuthenticator implements
         configProperties.add(email);
 
         return configProperties;
+    }
+
+    /**
+     * Returns AuthenticatedUser object from context.
+     *
+     * @param context AuthenticationContext.
+     * @return AuthenticatedUser.
+     */
+    private AuthenticatedUser getAuthenticatedUser(AuthenticationContext context) {
+
+        AuthenticatedUser authenticatedUser = null;
+        Map<Integer, StepConfig> stepConfigMap = context.getSequenceConfig().getStepMap();
+        for (StepConfig stepConfig : stepConfigMap.values()) {
+            AuthenticatedUser authenticatedUserInStepConfig = stepConfig.getAuthenticatedUser();
+            if (stepConfig.isSubjectAttributeStep() && authenticatedUserInStepConfig != null) {
+                authenticatedUser = stepConfig.getAuthenticatedUser();
+                break;
+            }
+        }
+        return authenticatedUser;
+    }
+
+    /**
+     * Get the user realm of the logged in user.
+     *
+     * @param authenticatedUser Authenticated user.
+     * @return UserRealm.
+     * @throws AuthenticationFailedException Exception on authentication failure.
+     */
+    private UserRealm getUserRealm(AuthenticatedUser authenticatedUser) throws AuthenticationFailedException {
+
+        UserRealm userRealm = null;
+        try {
+            if (authenticatedUser != null) {
+                String tenantDomain = authenticatedUser.getTenantDomain();
+                int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+                RealmService realmService = IdentityTenantUtil.getRealmService();
+                userRealm = realmService.getTenantUserRealm(tenantId);
+            }
+        } catch (UserStoreException e) {
+            throw new AuthenticationFailedException("Cannot find the user realm.", e);
+        }
+        return userRealm;
+    }
+
+    /**
+     * Reset OTP Failed Attempts count upon successful completion of the OTP verification.
+     *
+     * @param context Authentication context.
+     * @throws AuthenticationFailedException Exception on authentication failure.
+     */
+    private void resetOtpFailedAttempts(AuthenticationContext context) throws AuthenticationFailedException {
+
+        /*
+        Check whether account locking enabled for Email OTP to keep backward compatibility.
+        Account locking is not done for federated flows.
+         */
+        if (!isLocalUser(context) || !EmailOTPUtils.isAccountLockingEnabledForEmailOtp(context)) {
+            return;
+        }
+        AuthenticatedUser authenticatedUser = getAuthenticatedUser(context);
+
+        // Return if account lock handler is not enabled.
+        if (IdentityMgtConfig.getInstance().isAuthPolicyAccountLockOnFailure()) {
+            return;
+        }
+
+        String usernameWithDomain =
+                IdentityUtil.addDomainToName(authenticatedUser.getUserName(), authenticatedUser.getUserStoreDomain());
+        try {
+            UserRealm userRealm = getUserRealm(authenticatedUser);
+            UserStoreManager userStoreManager = userRealm.getUserStoreManager();
+
+            // Avoid updating the claims if they are already zero.
+            String[] claimsToCheck = {EmailOTPAuthenticatorConstants.EMAIL_OTP_FAILED_ATTEMPTS_CLAIM};
+            Map<String, String> userClaims = userStoreManager.getUserClaimValues(usernameWithDomain, claimsToCheck,
+                    UserCoreConstants.DEFAULT_PROFILE);
+            String failedEmailOtpAttempts =
+                    userClaims.get(EmailOTPAuthenticatorConstants.EMAIL_OTP_FAILED_ATTEMPTS_CLAIM);
+
+            if (NumberUtils.isNumber(failedEmailOtpAttempts) && Integer.parseInt(failedEmailOtpAttempts) > 0) {
+                Map<String, String> updatedClaims = new HashMap<>();
+                updatedClaims.put(EmailOTPAuthenticatorConstants.EMAIL_OTP_FAILED_ATTEMPTS_CLAIM, "0");
+                userStoreManager
+                        .setUserClaimValues(usernameWithDomain, updatedClaims, UserCoreConstants.DEFAULT_PROFILE);
+            }
+        } catch (UserStoreException e) {
+            String errorMessage =
+                    String.format("Failed to reset failed attempts count for user : %s.", authenticatedUser);
+            log.error(errorMessage, e);
+            throw new AuthenticationFailedException(errorMessage, e);
+        }
+    }
+
+    /**
+     * Execute account lock flow for OTP verification failures.
+     *
+     * @param context Authentication context.
+     * @throws AuthenticationFailedException Exception on authentication failure.
+     */
+    private void handleOtpVerificationFail(AuthenticationContext context) throws AuthenticationFailedException {
+
+        AuthenticatedUser authenticatedUser = getAuthenticatedUser(context);
+
+        /*
+        Account locking is not done for federated flows.
+        Check whether account locking enabled for Email OTP to keep backward compatibility.
+        No need to continue if the account is already locked.
+         */
+        if (!isLocalUser(context) || !EmailOTPUtils.isAccountLockingEnabledForEmailOtp(context) ||
+                EmailOTPUtils.isAccountLocked(authenticatedUser)) {
+            return;
+        }
+
+        if (!IdentityMgtConfig.getInstance().isAuthPolicyAccountLockOnFailure()) {
+            return;
+        }
+        int maxAttempts = IdentityMgtConfig.getInstance().getAuthPolicyMaxLoginAttempts();
+        long unlockTimePropertyValue = IdentityMgtConfig.getInstance().getAuthPolicyLockingTime();
+
+        Map<String, String> claimValues = getUserClaimValues(authenticatedUser);
+        if (claimValues == null) {
+            claimValues = new HashMap<>();
+        }
+        int currentAttempts = 0;
+        if (NumberUtils.isNumber(claimValues.get(EmailOTPAuthenticatorConstants.EMAIL_OTP_FAILED_ATTEMPTS_CLAIM))) {
+            currentAttempts =
+                    Integer.parseInt(claimValues.get(EmailOTPAuthenticatorConstants.EMAIL_OTP_FAILED_ATTEMPTS_CLAIM));
+        }
+
+        Map<String, String> updatedClaims = new HashMap<>();
+        if ((currentAttempts + 1) >= maxAttempts) {
+            // Calculate the incremental unlock-time-interval in milli seconds.
+            unlockTimePropertyValue = (long) (unlockTimePropertyValue * 1000 * 60 );
+            // Calculate unlock-time by adding current-time and unlock-time-interval in milli seconds.
+            long unlockTime = System.currentTimeMillis() + unlockTimePropertyValue;
+            updatedClaims.put(EmailOTPAuthenticatorConstants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
+            updatedClaims.put(EmailOTPAuthenticatorConstants.EMAIL_OTP_FAILED_ATTEMPTS_CLAIM, "0");
+            updatedClaims.put(EmailOTPAuthenticatorConstants.ACCOUNT_UNLOCK_TIME_CLAIM, String.valueOf(unlockTime));
+            IdentityUtil.threadLocalProperties.get().put(EmailOTPAuthenticatorConstants.ADMIN_INITIATED, false);
+            setUserClaimValues(authenticatedUser, updatedClaims);
+            throw new AuthenticationFailedException("Account is locked for the user: " + authenticatedUser.getUserName());
+        } else {
+            updatedClaims.put(EmailOTPAuthenticatorConstants.EMAIL_OTP_FAILED_ATTEMPTS_CLAIM,
+                    String.valueOf(currentAttempts + 1));
+            setUserClaimValues(authenticatedUser, updatedClaims);
+        }
+    }
+
+    /**
+     * Check whether the user being authenticated via a local authenticator or not.
+     *
+     * @param context Authentication context.
+     * @return Whether the user being authenticated via a local authenticator.
+     */
+    private boolean isLocalUser(AuthenticationContext context) {
+
+        Map<Integer, StepConfig> stepConfigMap = context.getSequenceConfig().getStepMap();
+        if (stepConfigMap != null) {
+            for (StepConfig stepConfig : stepConfigMap.values()) {
+                if (stepConfig.getAuthenticatedUser() != null && stepConfig.isSubjectAttributeStep() && StringUtils
+                        .equals(EmailOTPAuthenticatorConstants.LOCAL_AUTHENTICATOR, stepConfig.getAuthenticatedIdP())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private Map<String, String> getUserClaimValues(AuthenticatedUser authenticatedUser)
+            throws AuthenticationFailedException {
+
+        Map<String, String> claimValues;
+        try {
+            UserRealm userRealm = getUserRealm(authenticatedUser);
+            UserStoreManager userStoreManager = userRealm.getUserStoreManager();
+            claimValues = userStoreManager.getUserClaimValues(IdentityUtil.addDomainToName(
+                    authenticatedUser.getUserName(), authenticatedUser.getUserStoreDomain()), new String[]{
+                            EmailOTPAuthenticatorConstants.EMAIL_OTP_FAILED_ATTEMPTS_CLAIM},
+                    UserCoreConstants.DEFAULT_PROFILE);
+        } catch (UserStoreException e) {
+            log.error("Error while reading user claims.", e);
+            throw new AuthenticationFailedException(
+                    String.format("Failed to read user claims for user : %s.", authenticatedUser), e);
+        }
+        return claimValues;
+    }
+
+    private void setUserClaimValues(AuthenticatedUser authenticatedUser, Map<String, String> updatedClaims)
+            throws AuthenticationFailedException {
+
+        try {
+            UserRealm userRealm = getUserRealm(authenticatedUser);
+            UserStoreManager userStoreManager = userRealm.getUserStoreManager();
+            userStoreManager.setUserClaimValues(IdentityUtil.addDomainToName(authenticatedUser.getUserName(),
+                    authenticatedUser.getUserStoreDomain()), updatedClaims, UserCoreConstants.DEFAULT_PROFILE);
+        } catch (UserStoreException e) {
+            log.error("Error while updating user claims", e);
+            throw new AuthenticationFailedException(
+                    String.format("Failed to update user claims for user : %s.", authenticatedUser), e);
+        }
     }
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
@@ -88,6 +88,7 @@ public class EmailOTPAuthenticatorConstants {
     public static final String SUPER_TENANT = "carbon.super";
     public static final String USER_NAME = "username";
     public static final String AUTHENTICATED_USER = "authenticatedUser";
+    public static final String LOCAL_AUTHENTICATOR = "LOCAL";
 
     public static final String IS_EMAILOTP_MANDATORY = "EMAILOTPMandatory";
     public static final String EMAILOTP_AUTHENTICATION_ERROR_PAGE_URL = "EmailOTPAuthenticationEndpointErrorPage";
@@ -106,4 +107,12 @@ public class EmailOTPAuthenticatorConstants {
 
     public static final String SCREEN_VALUE = "&screenValue=";
     public static final String SHOW_EMAIL_ADDRESS_IN_UI = "showEmailAddressInUI";
+
+    // Account lock related constants.
+    public static final String EMAIL_OTP_FAILED_ATTEMPTS_CLAIM =
+            "http://wso2.org/claims/identity/failedEmailOtpAttempts";
+    public static final String ACCOUNT_LOCKED_CLAIM = "http://wso2.org/claims/identity/accountLocked";
+    public static final String ACCOUNT_UNLOCK_TIME_CLAIM = "http://wso2.org/claims/identity/unlockTime";
+    public static final String ENABLE_ACCOUNT_LOCKING_FOR_FAILED_ATTEMPTS = "EnableAccountLockingForFailedAttempts";
+    public static final String ADMIN_INITIATED = "AdminInitiated";
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/config/EmailOTPUtils.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/config/EmailOTPUtils.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.authenticator.emailotp.config;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.authentication.framework.config.builder.FileBasedConfigurationBuilder;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.authenticator.emailotp.EmailOTPAuthenticatorConstants;
+import org.wso2.carbon.identity.authenticator.emailotp.internal.EmailOTPServiceDataHolder;
+import org.wso2.carbon.identity.mgt.AccountLockServiceException;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class EmailOTPUtils {
+
+    private static final Log log = LogFactory.getLog(EmailOTPUtils.class);
+
+    /**
+     * Get parameter values from application-authentication.xml file.
+     */
+    public static Map<String, String> getEmailParameters() {
+
+        AuthenticatorConfig authConfig = FileBasedConfigurationBuilder.getInstance()
+                .getAuthenticatorBean(EmailOTPAuthenticatorConstants.AUTHENTICATOR_NAME);
+        if (authConfig != null) {
+            return authConfig.getParameterMap();
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Authenticator config related to given config name not found. Hence returning an empty map.");
+        }
+        return Collections.emptyMap();
+    }
+
+    /**
+     * Get the corresponding configuration from Email parameters.
+     *
+     * @param context    Authentication Context.
+     * @param configName Name of the config.
+     * @return Config value.
+     */
+    public static String getConfiguration(AuthenticationContext context, String configName) {
+
+        String configValue = null;
+        if (getEmailParameters().containsKey(configName)) {
+            configValue = getEmailParameters().get(configName);
+        } else if ((context.getProperty(configName)) != null) {
+            configValue = String.valueOf(context.getProperty(configName));
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Config value for key " + configName + ": " + configValue);
+        }
+        return configValue;
+    }
+
+    /**
+     * Check whether account locking is enabled for Email OTP.
+     *
+     * @param context Authentication context.
+     * @return Whether account locking is enabled for Email OTP.
+     */
+    public static boolean isAccountLockingEnabledForEmailOtp(AuthenticationContext context) {
+
+        return Boolean.parseBoolean(getConfiguration(context,
+                EmailOTPAuthenticatorConstants.ENABLE_ACCOUNT_LOCKING_FOR_FAILED_ATTEMPTS));
+    }
+
+    /**
+     * Check whether a given user is locked.
+     *
+     * @param authenticatedUser Authenticated user.
+     * @return True if user account is locked.
+     * @throws AuthenticationFailedException Exception on authentication failure.
+     */
+    public static boolean isAccountLocked(AuthenticatedUser authenticatedUser) throws AuthenticationFailedException {
+
+        try {
+            return EmailOTPServiceDataHolder.getInstance().getAccountLockService()
+                    .isAccountLocked(authenticatedUser.getUserName(), authenticatedUser.getTenantDomain(),
+                            authenticatedUser.getUserStoreDomain());
+        } catch (AccountLockServiceException e) {
+            throw new AuthenticationFailedException("Error while validating account lock status of user: " +
+                    authenticatedUser.getUserName(), e);
+        }
+    }
+}

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/internal/EmailOTPAuthenticatorServiceComponent.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/internal/EmailOTPAuthenticatorServiceComponent.java
@@ -24,11 +24,15 @@ import org.apache.commons.logging.LogFactory;
 import org.osgi.service.component.ComponentContext;
 import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
 import org.wso2.carbon.identity.authenticator.emailotp.EmailOTPAuthenticator;
+import org.wso2.carbon.identity.mgt.account.lock.AccountLockService;
 
 import java.util.Hashtable;
 
 /**
  * @scr.component name="identity.application.authenticator.emailotp.component" immediate="true"
+ * @scr.reference name="org.wso2.carbon.identity.mgt.account.lock.AccountLockService"
+ * interface="org.wso2.carbon.identity.mgt.account.lock.AccountLockService"
+ * cardinality="1..1" policy="dynamic" bind="setAccountLockService" unbind="unsetAccountLockService"
  */
 public class EmailOTPAuthenticatorServiceComponent {
 
@@ -52,5 +56,15 @@ public class EmailOTPAuthenticatorServiceComponent {
         if (log.isDebugEnabled()) {
             log.debug("EmailOTP authenticator is deactivated");
         }
+    }
+
+    protected void setAccountLockService(AccountLockService accountLockService) {
+
+        EmailOTPServiceDataHolder.getInstance().setAccountLockService(accountLockService);
+    }
+
+    protected void unsetAccountLockService(AccountLockService accountLockService) {
+
+        EmailOTPServiceDataHolder.getInstance().setAccountLockService(null);
     }
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/internal/EmailOTPServiceDataHolder.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/internal/EmailOTPServiceDataHolder.java
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+package org.wso2.carbon.identity.authenticator.emailotp.internal;
+
+import org.wso2.carbon.identity.mgt.account.lock.AccountLockService;
+import org.wso2.carbon.user.core.service.RealmService;
+
+/**
+ *  Encapsulates the data of EmailOTP authenticator.
+ */
+public class EmailOTPServiceDataHolder {
+
+    private static EmailOTPServiceDataHolder emailOTPServiceDataHolder;
+    private AccountLockService accountLockService;
+    private RealmService realmService;
+
+    /**
+     * Returns the DataHolder instance.
+     *
+     * @return The DataHolder instance
+     */
+    public static EmailOTPServiceDataHolder getInstance() {
+
+        if (emailOTPServiceDataHolder == null) {
+            emailOTPServiceDataHolder = new EmailOTPServiceDataHolder();
+        }
+        return emailOTPServiceDataHolder;
+    }
+
+    /**
+     * Returns the Realm service.
+     *
+     * @return Realm service.
+     */
+    public RealmService getRealmService() {
+
+        return realmService;
+    }
+
+    /**
+     * Sets the Realm service.
+     *
+     * @param realmService Realm service.
+     */
+    public void setRealmService(RealmService realmService) {
+
+        this.realmService = realmService;
+    }
+
+    /**
+     * Get Account Lock service.
+     *
+     * @return Account Lock service.
+     */
+    public AccountLockService getAccountLockService() {
+
+        return accountLockService;
+    }
+
+    /**
+     * Set Account Lock service.
+     *
+     * @param accountLockService Account Lock service.
+     */
+    public void setAccountLockService(AccountLockService accountLockService) {
+
+        this.accountLockService = accountLockService;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -68,12 +68,6 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity</groupId>
-            <artifactId>org.wso2.carbon.identity.user.account.association</artifactId>
-            <version>${carbon.identity.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.identity</groupId>
             <artifactId>org.wso2.carbon.identity.core</artifactId>
             <version>${carbon.identity.version}</version>
             <scope>provided</scope>
@@ -131,15 +125,9 @@
             <version>1.0.1</version>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.identity</groupId>
-            <artifactId>org.wso2.carbon.identity.application.authenticator.openid</artifactId>
-            <version>${carbon.identity.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.identity</groupId>
+            <groupId>org.wso2.carbon.identity.outbound.auth.oidc</groupId>
             <artifactId>org.wso2.carbon.identity.application.authenticator.oidc</artifactId>
-            <version>${carbon.identity.version}</version>
+            <version>${org.wso2.carbon.identity.outbound.auth.oidc}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -162,8 +150,7 @@
         <dependency>
             <groupId>org.wso2.carbon.identity</groupId>
             <artifactId>org.wso2.carbon.identity.mgt</artifactId>
-            <version>5.0.7</version>
-            <scope>provided</scope>
+            <version>${carbon.identity.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-lang.wso2</groupId>
@@ -391,9 +378,10 @@
         </snapshotRepository>
     </distributionManagement>
     <properties>
-        <carbon.identity.version>5.0.7</carbon.identity.version>
+        <carbon.identity.version>5.2.2</carbon.identity.version>
         <commons-logging.version>4.4.3</commons-logging.version>
         <carbon.kernel.version>4.4.3</carbon.kernel.version>
+        <org.wso2.carbon.identity.outbound.auth.oidc>5.1.20</org.wso2.carbon.identity.outbound.auth.oidc>
         <oltu.version>1.0.0.wso2v2</oltu.version>
         <org.apache.oltu.oauth2.client.version>1.0.0</org.apache.oltu.oauth2.client.version>
         <oltu.package.import.version.range>[1.0.0, 2.0.0)</oltu.package.import.version.range>


### PR DESCRIPTION
## Purpose
Backport fix of https://github.com/wso2-extensions/identity-outbound-auth-email-otp/pull/79
Related PR: wso2-support/carbon-identity-framework#1440

Writing unit tests is in progress. Unit tests will be added before merging the PR.