### PR TITLE
Fix account locking related claims not updating issue for previously locked users.

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -2326,19 +2326,28 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
 
             // Avoid updating the claims if they are already zero.
             String[] claimsToCheck = {EmailOTPAuthenticatorConstants.EMAIL_OTP_FAILED_ATTEMPTS_CLAIM,
-                    EmailOTPAuthenticatorConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM};
+                    EmailOTPAuthenticatorConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM,
+                    EmailOTPAuthenticatorConstants.ACCOUNT_LOCKED_CLAIM};
             Map<String, String> userClaims = userStoreManager.getUserClaimValues(usernameWithDomain, claimsToCheck,
                     UserCoreConstants.DEFAULT_PROFILE);
             String failedEmailOtpAttempts =
                     userClaims.get(EmailOTPAuthenticatorConstants.EMAIL_OTP_FAILED_ATTEMPTS_CLAIM);
             String failedLoginLockoutCount =
                     userClaims.get(EmailOTPAuthenticatorConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM);
+            String accountLockClaim =
+                    userClaims.get(EmailOTPAuthenticatorConstants.ACCOUNT_LOCKED_CLAIM);
 
             if (NumberUtils.isNumber(failedEmailOtpAttempts) && Integer.parseInt(failedEmailOtpAttempts) > 0 ||
                     NumberUtils.isNumber(failedLoginLockoutCount) && Integer.parseInt(failedLoginLockoutCount) > 0) {
                 Map<String, String> updatedClaims = new HashMap<>();
                 updatedClaims.put(EmailOTPAuthenticatorConstants.EMAIL_OTP_FAILED_ATTEMPTS_CLAIM, "0");
                 updatedClaims.put(EmailOTPAuthenticatorConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM, "0");
+                // Check the account lock claim to verify whether the user is previously locked.
+                if (Boolean.parseBoolean(accountLockClaim)) {
+                    // Update the account locking related claims upon successful completion of the OTP verification.
+                    updatedClaims.put(EmailOTPAuthenticatorConstants.ACCOUNT_LOCKED_CLAIM, Boolean.FALSE.toString());
+                    updatedClaims.put(EmailOTPAuthenticatorConstants.ACCOUNT_UNLOCK_TIME_CLAIM, "0");
+                }
                 userStoreManager
                         .setUserClaimValues(usernameWithDomain, updatedClaims, UserCoreConstants.DEFAULT_PROFILE);
             }


### PR DESCRIPTION
## Purpose
This PR changes will fix account locking related claims not updating issue for previously locked users.
Resolves: https://github.com/wso2/product-is/issues/13530
Frontport fix: https://github.com/wso2-extensions/identity-outbound-auth-email-otp/pull/126

## Approach
Update the ‘Account Locked' claim and 'Account Unlock Time' claim in the same way we do for the ‘Failed Login Lockout Count’ claim after a successful email otp verification of a previously locked user.
