### PR TITLE
[IS-5.10.0] Check user existence before checking the email otp is disabled for the user

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -2630,8 +2630,14 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator impl
         AuthenticatedUser authenticatedUser = (AuthenticatedUser) context.getProperty(EmailOTPAuthenticatorConstants
                 .AUTHENTICATED_USER);
         Map<String, String> emailOTPParameters = getAuthenticatorConfig().getParameterMap();
-        if (isEmailOTPDisableForUser(authenticatedUser.getAuthenticatedSubjectIdentifier(),
-                context, emailOTPParameters)) {
+        String username = authenticatedUser.getAuthenticatedSubjectIdentifier();
+        boolean isUserExist;
+        try {
+            isUserExist = FederatedAuthenticatorUtil.isUserExistInUserStore(username);
+        } catch (UserStoreException e) {
+            throw new AuthenticationFailedException("Failed to get the user from user store.", e);
+        }
+        if (isUserExist && isEmailOTPDisableForUser(username, context, emailOTPParameters)) {
             // Email OTP is disabled for the user. Hence not going to trigger the event.
             return;
         }


### PR DESCRIPTION
## Purpose
Check user existence before checking the email otp is disabled for the federated users

## Related Issue
Resolves wso2/product-is#14123

