### PR TITLE
Check user existence before checking the email otp is disabled for the user

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -2559,7 +2559,14 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
         AuthenticatedUser authenticatedUser = (AuthenticatedUser) context.getProperty(EmailOTPAuthenticatorConstants
                 .AUTHENTICATED_USER);
         Map<String, String> emailOTPParameters = getAuthenticatorConfig().getParameterMap();
-        if (isEmailOTPDisableForUser(authenticatedUser, context, emailOTPParameters)) {
+        String username = authenticatedUser.getAuthenticatedSubjectIdentifier();
+        boolean isUserExist;
+        try {
+            isUserExist = FederatedAuthenticatorUtil.isUserExistInUserStore(username);
+        } catch (UserStoreException e) {
+            throw new AuthenticationFailedException("Failed to get the user from user store.", e);
+        }
+        if (isUserExist && isEmailOTPDisableForUser(username, context, emailOTPParameters)) {
             // Email OTP is disabled for the user. Hence not going to trigger the event.
             return;
         }


### PR DESCRIPTION
## Purpose
Check user existence before checking the email otp is disabled for the federated users

## Related Issue
Resolves wso2/product-is#14123

