### PR TITLE
feature: add maxValidationAttemptsAllowed

### DIFF
--- a/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/constant/Constants.java
+++ b/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/constant/Constants.java
@@ -40,6 +40,8 @@ public class Constants {
     public static final int DEFAULT_EMAIL_OTP_EXPIRY_TIME = 120000;
     public static final int DEFAULT_EMAIL_RESEND_THROTTLE_INTERVAL = 30000;
 
+    public static final int DEFAULT_MAX_VALIDATION_ATTEMPTS_ALLOWED = 5;
+
     public static final String EMAIL_OTP_IDENTITY_EVENT_MODULE_NAME = "emailOtp";
     public static final String EMAIL_OTP_ENABLED = "emailOtp.enabled";
     public static final String EMAIL_OTP_LENGTH = "emailOtp.tokenLength";
@@ -48,6 +50,8 @@ public class Constants {
     public static final String EMAIL_OTP_TRIGGER_OTP_NOTIFICATION = "emailOtp.triggerNotification";
     public static final String EMAIL_OTP_RENEWAL_INTERVAL = "emailOtp.tokenRenewalInterval";
     public static final String EMAIL_OTP_RESEND_THROTTLE_INTERVAL = "emailOtp.resendThrottleInterval";
+
+    public static final String EMAIL_OTP_MAX_VALIDATION_ATTEMPTS_ALLOWED = "emailOtp.maxValidationAttemptsAllowed";
     public static final String EMAIL_OTP_SHOW_FAILURE_REASON = "emailOtp.showValidationFailureReason";
 
     /**
@@ -76,6 +80,8 @@ public class Constants {
                 "Please wait %s seconds before retrying."),
         CLIENT_NO_OTP_FOR_USER("EMAIL-60011", "No OTP fround for the user.",
                 "No OTP found for the user Id : %s."),
+        CLIENT_OTP_VALIDATION_BLOCKED("EMAIL-60011", "Maximum allowed failed validation attempts exceeded.",
+                "Maximum allowed failed validation attempts exceeded for user id : %s."),
 
         // Server error codes.
         SERVER_USER_STORE_MANAGER_ERROR("EMAIL-65001", "User store manager error.",

--- a/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/dto/ConfigsDTO.java
+++ b/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/dto/ConfigsDTO.java
@@ -34,6 +34,8 @@ public class ConfigsDTO {
     private int otpRenewalInterval;
     private int resendThrottleInterval;
 
+    private int maxValidationAttemptsAllowed;
+
     public boolean isEnabled() {
 
         return isEnabled;
@@ -134,6 +136,16 @@ public class ConfigsDTO {
         this.resendThrottleInterval = resendThrottleInterval;
     }
 
+    public int getMaxValidationAttemptsAllowed() {
+
+        return maxValidationAttemptsAllowed;
+    }
+
+    public void setMaxValidationAttemptsAllowed(int maxValidationAttemptsAllowed) {
+
+        this.maxValidationAttemptsAllowed = maxValidationAttemptsAllowed;
+    }
+
     @Override
     public String toString() {
 
@@ -148,6 +160,7 @@ public class ConfigsDTO {
                 .append(",\n\totpValidityPeriod = ").append(otpValidityPeriod)
                 .append(",\n\totpRenewalInterval = ").append(otpRenewalInterval)
                 .append(",\n\tresendThrottleInterval = ").append(resendThrottleInterval)
+                .append(",\n\tmaxValidationAttemptsAllowed = ").append(maxValidationAttemptsAllowed)
                 .append("\n}");
         return sb.toString();
     }

--- a/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/dto/FailureReasonDTO.java
+++ b/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/dto/FailureReasonDTO.java
@@ -30,12 +30,22 @@ public class FailureReasonDTO {
     String code;
     String message;
     String description;
+    int remainingAttempts;
 
     public FailureReasonDTO(String code, String message, String description) {
 
         this.code = code;
         this.message = message;
         this.description = description;
+        this.remainingAttempts = 0;
+    }
+
+    public FailureReasonDTO(String code, String message, String description, int remainingAttempts) {
+
+        this.code = code;
+        this.message = message;
+        this.description = description;
+        this.remainingAttempts = remainingAttempts;
     }
 
     public FailureReasonDTO(Constants.ErrorMessage error, String data) {
@@ -44,6 +54,23 @@ public class FailureReasonDTO {
         this.message = error.getMessage();
         description = StringUtils.isNotBlank(data) ? String.format(error.getDescription(), data)
                 : error.getDescription();
+        this.remainingAttempts = 0;
+    }
+
+    /**
+     * This method composes the error message for failed sms-otp validation attempts.
+     *
+     * @param error                     Error message.
+     * @param data                      Data passed for the string argument in error message.
+     * @param remainingFailedAttempts   No of remaining validation attempts.
+     */
+    public FailureReasonDTO(Constants.ErrorMessage error, String data, int remainingFailedAttempts) {
+
+        this.code = error.getCode();
+        this.message = error.getMessage();
+        description = StringUtils.isNotBlank(data) ? String.format(error.getDescription(), data)
+                : error.getDescription();
+        this.remainingAttempts = remainingFailedAttempts;
     }
 
     public String getCode() {
@@ -74,5 +101,15 @@ public class FailureReasonDTO {
     public void setDescription(String description) {
 
         this.description = description;
+    }
+
+    public int getRemainingAttempts() {
+
+        return remainingAttempts;
+    }
+
+    public void setRemainingAttempts(int remainingAttempts) {
+
+        this.remainingAttempts = remainingAttempts;
     }
 }

--- a/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/dto/SessionDTO.java
+++ b/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/dto/SessionDTO.java
@@ -34,6 +34,7 @@ public class SessionDTO implements Serializable {
     private String transactionId;
     private String fullQualifiedUserName;
     private String userId;
+    private int validationAttempts;
 
     public String getOtpToken() {
 
@@ -95,6 +96,16 @@ public class SessionDTO implements Serializable {
         this.userId = userId;
     }
 
+    public int getValidationAttempts() {
+
+        return validationAttempts;
+    }
+
+    public void setValidationAttempts(int validationAttempts) {
+
+        this.validationAttempts = validationAttempts;
+    }
+
     @Override
     public boolean equals(Object o) {
 
@@ -110,14 +121,15 @@ public class SessionDTO implements Serializable {
                 getOtpToken().equals(that.getOtpToken()) &&
                 getTransactionId().equals(that.getTransactionId()) &&
                 getFullQualifiedUserName().equals(that.getFullQualifiedUserName()) &&
-                getUserId().equals(that.getUserId());
+                getUserId().equals(that.getUserId()) &&
+                getValidationAttempts() == that.getValidationAttempts();
     }
 
     @Override
     public int hashCode() {
 
         return Objects.hash(getOtpToken(), getGeneratedTime(), getExpiryTime(), getTransactionId(),
-                getFullQualifiedUserName(), getUserId());
+                getFullQualifiedUserName(), getUserId(), getValidationAttempts());
     }
 
     @Override
@@ -130,6 +142,7 @@ public class SessionDTO implements Serializable {
                 ", transactionId='" + transactionId + '\'' +
                 ", fullQualifiedUserName='" + fullQualifiedUserName + '\'' +
                 ", userId='" + userId + '\'' +
+                ", validationAttempts='" + validationAttempts + '\'' +
                 '}';
     }
 }

--- a/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/util/Utils.java
+++ b/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/util/Utils.java
@@ -127,6 +127,14 @@ public class Utils {
                 Constants.DEFAULT_EMAIL_RESEND_THROTTLE_INTERVAL;
         configs.setResendThrottleInterval(resendThrottleInterval);
 
+        // Maximum allowed validation attempts defaults to 5 if its not specified as a property in deployment.toml file.
+        String otpMaxValidationAttemptsAllowedValue = StringUtils.trim(
+                properties.getProperty(Constants.EMAIL_OTP_MAX_VALIDATION_ATTEMPTS_ALLOWED));
+        int maxValidationAttemptsAllowed = StringUtils.isNumeric(otpMaxValidationAttemptsAllowedValue) ?
+                Integer.parseInt(otpMaxValidationAttemptsAllowedValue) :
+                Constants.DEFAULT_MAX_VALIDATION_ATTEMPTS_ALLOWED;
+        configs.setMaxValidationAttemptsAllowed(maxValidationAttemptsAllowed);
+
         // Should we send the same OTP upon the next generation request? Defaults to 'false'.
         boolean resendSameOtp = (otpRenewalInterval > 0) && (otpRenewalInterval < otpValidityPeriod);
         configs.setResendSameOtp(resendSameOtp);


### PR DESCRIPTION
## Purpose
> Implemented the feature to set the maximum validation attempts allowed until the generated email-otp expires.

## Goals
> Adding the properties.maxValidationAttemptsAllowed = 2 on deployment.toml is possible to set the maximum validation attempts allowed until the generated email-otp

