### PR TITLE
Update Dependencies to IPK versions

### DIFF
--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -61,6 +61,7 @@
                             org.wso2.carbon.identity.mgt.*; version="${carbon.identity.package.import.version.range}",
                             org.apache.commons.logging.*; version="1.0.4",
                             org.osgi.framework,
+                            org.osgi.service.component; version="${osgi.service.import.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.*,
                             javax.servlet,
                             javax.servlet.http,

--- a/pom.xml
+++ b/pom.xml
@@ -218,9 +218,9 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon.identity</groupId>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.mgt</artifactId>
-                <version>5.0.7</version>
+                <version>${carbon.identity.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
@@ -242,8 +242,12 @@
                         <artifactId>slf4j-jdk14</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>org.wso2.carbon.identity</groupId>
+                        <groupId>org.wso2.carbon.identity.framework</groupId>
                         <artifactId>org.wso2.carbon.identity.provider</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javassist</groupId>
+                        <artifactId>javassist</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -469,16 +473,16 @@
     </distributionManagement>
 
     <properties>
-        <carbon.identity.version>5.20.144</carbon.identity.version>
-        <carbon.identity.event.version>5.18.209</carbon.identity.event.version>
+        <carbon.identity.version>6.0.0</carbon.identity.version>
+        <carbon.identity.event.version>6.0.0</carbon.identity.event.version>
         <commons-logging.version>4.4.3</commons-logging.version>
         <carbon.kernel.version>4.7.0</carbon.kernel.version>
-        <identity.governance.version>1.4.1</identity.governance.version>
+        <identity.governance.version>2.0.0</identity.governance.version>
         <oltu.version>1.0.0.wso2v2</oltu.version>
         <org.apache.oltu.oauth2.client.version>1.0.0</org.apache.oltu.oauth2.client.version>
         <oltu.package.import.version.range>[1.0.0, 2.0.0)</oltu.package.import.version.range>
         <wso2.json>3.0.0.wso2v1</wso2.json>
-        <carbon.identity.package.import.version.range>[5.0.0, 6.0.0)</carbon.identity.package.import.version.range>
+        <carbon.identity.package.import.version.range>[6.0.0, 7.0.0)</carbon.identity.package.import.version.range>
         <jackson-jaxrs-json-provider.version>2.9.9</jackson-jaxrs-json-provider.version>
         <javax.servlet-api.version>3.0-alpha-1</javax.servlet-api.version>
         <taglibs-standard-impl.version>1.2.5</taglibs-standard-impl.version>
@@ -487,14 +491,14 @@
         <org.wso2.securevault.version>1.0.0-wso2v2</org.wso2.securevault.version>
         <commons-lang.wso2.version>2.6.0.wso2v1</commons-lang.wso2.version>
         <encoder.wso2.version>1.2.0.wso2v1</encoder.wso2.version>
-        <identity.extension.utils>1.0.8</identity.extension.utils>
-        <identity.extension.utils.import.version.range>[1.0.8,2.0.0)
+        <identity.extension.utils>2.0.0</identity.extension.utils>
+        <identity.extension.utils.import.version.range>[2.0.0,3.0.0)
         </identity.extension.utils.import.version.range>
         <log4j.version>1.2.16</log4j.version>
         <org.wso2.carbon.identity.association.account>5.1.5</org.wso2.carbon.identity.association.account>
-        <identity.outbound.auth.oidc.import.version.range>[5.1.20,6.0.0)</identity.outbound.auth.oidc.import.version.range>
-        <carbon.identity.account.lock.handler.version>1.1.12</carbon.identity.account.lock.handler.version>
-        <carbon.identity.account.lock.handler.imp.pkg.version.range>[1.1.12, 2.0.0)
+        <identity.outbound.auth.oidc.import.version.range>[6.0.0,7.0.0)</identity.outbound.auth.oidc.import.version.range>
+        <carbon.identity.account.lock.handler.version>2.0.0</carbon.identity.account.lock.handler.version>
+        <carbon.identity.account.lock.handler.imp.pkg.version.range>[2.0.0, 3.0.0)
         </carbon.identity.account.lock.handler.imp.pkg.version.range>
         <!--Test Dependencies-->
         <junit.version>4.13.1</junit.version>
@@ -508,12 +512,12 @@
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
         <osgi.service.import.version.range>[1.2.0,2.0.0)</osgi.service.import.version.range>
         <import.package.version.commons.logging>[1.2.0,2.0.0)</import.package.version.commons.logging>
-        <carbon.identity.package.import.version.range>[5.14.0, 6.0.0)</carbon.identity.package.import.version.range>
-        <carbon.identity.framework.imp.pkg.version.range>[5.15.28, 6.0.0)
+        <carbon.identity.package.import.version.range>[6.0.0, 7.0.0)</carbon.identity.package.import.version.range>
+        <carbon.identity.framework.imp.pkg.version.range>[6.0.0, 7.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
-        <identity.governance.imp.pkg.version.range>[1.3.9, 2.0.0)</identity.governance.imp.pkg.version.range>
+        <identity.governance.imp.pkg.version.range>[2.0.0, 3.0.0)</identity.governance.imp.pkg.version.range>
         <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>
         <commons-lang.version.range>[2.6.0,4.0.0)</commons-lang.version.range>
     </properties>


### PR DESCRIPTION
The identity components are bumped to major versions created for IPK.

Related issue: https://github.com/wso2-enterprise/identity-k8s-access-runtime/issues/16