### PR TITLE
validation URL not invalidated issue fixed for Multiple email OTP session flow

### DIFF
--- a/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/EmailOtpServiceImpl.java
+++ b/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/EmailOtpServiceImpl.java
@@ -206,7 +206,7 @@ public class EmailOtpServiceImpl implements EmailOtpService {
                 return responseDTO;
             }
             // Valid OTP. Clear OTP session data.
-                SessionDataStore.getInstance().clearSessionData(Utils.getHash(userId, transactionId), Constants.SESSION_TYPE_OTP);
+                SessionDataStore.getInstance().clearSessionData(Utils.getHash(userId), Constants.SESSION_TYPE_OTP);
 
             return new ValidationResponseDTO(userId, true);
         } else {
@@ -233,9 +233,6 @@ public class EmailOtpServiceImpl implements EmailOtpService {
             if (!responseDTO.isValid()) {
                 return responseDTO;
             }
-
-            // Valid OTP. Clear OTP session data.
-            SessionDataStore.getInstance().clearSessionData(Utils.getHash(userId, transactionId), Constants.SESSION_TYPE_OTP);
 
             return new ValidationResponseDTO(userId, true);
         }

--- a/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/EmailOtpServiceImpl.java
+++ b/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/EmailOtpServiceImpl.java
@@ -234,6 +234,9 @@ public class EmailOtpServiceImpl implements EmailOtpService {
                 return responseDTO;
             }
 
+            // Valid OTP. Clear OTP session data.
+            SessionDataStore.getInstance().clearSessionData(Utils.getHash(userId, transactionId), Constants.SESSION_TYPE_OTP);
+
             return new ValidationResponseDTO(userId, true);
         }
     }


### PR DESCRIPTION
When Multiple Email OTP sessions enabled, validate request is not invalidating the otp after validating.
This is to fix this issue for Multiple email OTP session flow.