### PR TITLE
Remove failed login lockout count claim reset logic

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -2326,22 +2326,17 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
 
             // Avoid updating the claims if they are already zero.
             String[] claimsToCheck = {EmailOTPAuthenticatorConstants.EMAIL_OTP_FAILED_ATTEMPTS_CLAIM,
-                    EmailOTPAuthenticatorConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM,
                     EmailOTPAuthenticatorConstants.ACCOUNT_LOCKED_CLAIM};
             Map<String, String> userClaims = userStoreManager.getUserClaimValues(usernameWithDomain, claimsToCheck,
                     UserCoreConstants.DEFAULT_PROFILE);
             String failedEmailOtpAttempts =
                     userClaims.get(EmailOTPAuthenticatorConstants.EMAIL_OTP_FAILED_ATTEMPTS_CLAIM);
-            String failedLoginLockoutCount =
-                    userClaims.get(EmailOTPAuthenticatorConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM);
             String accountLockClaim =
                     userClaims.get(EmailOTPAuthenticatorConstants.ACCOUNT_LOCKED_CLAIM);
 
-            if (NumberUtils.isNumber(failedEmailOtpAttempts) && Integer.parseInt(failedEmailOtpAttempts) > 0 ||
-                    NumberUtils.isNumber(failedLoginLockoutCount) && Integer.parseInt(failedLoginLockoutCount) > 0) {
+            if (NumberUtils.isNumber(failedEmailOtpAttempts) && Integer.parseInt(failedEmailOtpAttempts) > 0) {
                 Map<String, String> updatedClaims = new HashMap<>();
                 updatedClaims.put(EmailOTPAuthenticatorConstants.EMAIL_OTP_FAILED_ATTEMPTS_CLAIM, "0");
-                updatedClaims.put(EmailOTPAuthenticatorConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM, "0");
                 // Check the account lock claim to verify whether the user is previously locked.
                 if (Boolean.parseBoolean(accountLockClaim)) {
                     // Update the account locking related claims upon successful completion of the OTP verification.


### PR DESCRIPTION
## Purpose
> In a MFA scenario, if a user successfully authenticates a step, the `FailedLoginLockoutCount` claim gets reset. But, there can be authentication failures after a successful authentication in MFA scenarios.

## Goals
> Resetting the above mentioned claim only for once and it should happen after a complete successful authentication flow.

## Approach
> Removing the claim reset logic in authenticator level and Introducing a new post authentication handler to reset the claim after a successful authentication flow.

PR for new post authentication handler: https://github.com/wso2-extensions/identity-event-handler-account-lock/pull/119
Related issue: https://github.com/wso2/product-is/issues/14928