### PR TITLE
Add logic to build redirect url by considering the expired otp

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -1075,7 +1075,12 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator impl
                     && !isEmailUpdateFailed(context)) {
                 // Build redirect url by validating whether the otp has been expired or not.
                 if (isOTPExpired(context)) {
-                    url = url + EmailOTPAuthenticatorConstants.ERROR_TOKEN_EXPIRED;
+                    // Differentiating the error message according to the config disableOTPResendOnFailure.
+                    if (isOTPResendingDisabledOnFailure(context)){
+                        url = url + EmailOTPAuthenticatorConstants.ERROR_TOKEN_EXPIRED;
+                    } else {
+                        url = url + EmailOTPAuthenticatorConstants.ERROR_TOKEN_EXPIRED_EMAIL_SENT;
+                    }
                 } else {
                     url = url + EmailOTPAuthenticatorConstants.RETRY_PARAMS;
                 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -306,6 +306,8 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator impl
 
 
         AuthenticatedUser authenticatedUser = getAuthenticatedUser(context);
+        // Set isOTPExpired property to false initially in the context whenever the authentication response is received.
+        context.setProperty(EmailOTPAuthenticatorConstants.OTP_EXPIRED, "false");
         boolean isLocalUser = isLocalUser(context);
         if (authenticatedUser == null) {
             String errorMessage = "Could not find an Authenticated user in the context.";
@@ -1008,7 +1010,6 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator impl
                 String ipAddress = IdentityUtil.getClientIpAddress(request);
                 context.setProperty(EmailOTPAuthenticatorConstants.OTP_TOKEN, myToken);
                 context.setProperty(EmailOTPAuthenticatorConstants.OTP_GENERATED_TIME, System.currentTimeMillis());
-                context.setProperty(EmailOTPAuthenticatorConstants.OTP_EXPIRED, "false");
                 if (authenticatorProperties != null) {
                     if (StringUtils.isNotEmpty(myToken)) {
                         checkEmailOTPBehaviour(context, emailOTPParameters, authenticatorProperties, email, username,
@@ -1072,7 +1073,12 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator impl
             if (context.isRetrying()
                     && !Boolean.parseBoolean(request.getParameter(EmailOTPAuthenticatorConstants.RESEND))
                     && !isEmailUpdateFailed(context)) {
-                url = url + EmailOTPAuthenticatorConstants.RETRY_PARAMS;
+                // Build redirect url by validating whether the otp has been expired or not.
+                if (isOTPExpired(context)) {
+                    url = url + EmailOTPAuthenticatorConstants.ERROR_TOKEN_EXPIRED;
+                } else {
+                    url = url + EmailOTPAuthenticatorConstants.RETRY_PARAMS;
+                }
             }
             response.sendRedirect(url);
         } catch (IOException e) {

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
@@ -117,6 +117,7 @@ public class EmailOTPAuthenticatorConstants {
     public static final String PASS_SP_NAME_TO_EVENT = "passSPNameToEvent";
 
     public static final String SCREEN_VALUE = "&screenValue=";
+    public static final String ERROR_TOKEN_EXPIRED_EMAIL_SENT = "&authFailure=true&authFailureMsg=token.expired.email.sent";
     public static final String ERROR_TOKEN_EXPIRED = "&authFailure=true&authFailureMsg=token.expired";
     public static final String SHOW_EMAIL_ADDRESS_IN_UI = "showEmailAddressInUI";
     public static final String EMAIL_ADDRESS_REGEX = "emailAddressRegex";

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
@@ -117,6 +117,7 @@ public class EmailOTPAuthenticatorConstants {
     public static final String PASS_SP_NAME_TO_EVENT = "passSPNameToEvent";
 
     public static final String SCREEN_VALUE = "&screenValue=";
+    public static final String ERROR_TOKEN_EXPIRED = "&authFailure=true&authFailureMsg=token.expired";
     public static final String SHOW_EMAIL_ADDRESS_IN_UI = "showEmailAddressInUI";
     public static final String EMAIL_ADDRESS_REGEX = "emailAddressRegex";
     public static final String USE_EVENT_HANDLER_BASED_EMAIL_SENDER = "useEventHandlerBasedEmailSender";


### PR DESCRIPTION
### Purpose

Redirect URL has been built with the query param `&authFailure=true&authFailureMsg=token.expired` whenever a user enters an OTP after the OTP has been expired

### Related Issue
- https://github.com/wso2/product-is/issues/15541