### PR TITLE
Add logic to build redirect url by considering the expired otp

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -1065,7 +1065,12 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
                     && !isEmailUpdateFailed(context)) {
                 // Build redirect url by validating whether the otp has been expired or not.
                 if (isOTPExpired(context)) {
-                    url = url + EmailOTPAuthenticatorConstants.ERROR_TOKEN_EXPIRED;
+                    // Differentiating the error message according to the config disableOTPResendOnFailure.
+                    if (isOTPResendingDisabledOnFailure(context)){
+                        url = url + EmailOTPAuthenticatorConstants.ERROR_TOKEN_EXPIRED;
+                    } else {
+                        url = url + EmailOTPAuthenticatorConstants.ERROR_TOKEN_EXPIRED_EMAIL_SENT;
+                    }
                 } else {
                     url = url + EmailOTPAuthenticatorConstants.RETRY_PARAMS;
                 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
@@ -128,6 +128,7 @@ public class EmailOTPAuthenticatorConstants {
     public static final String PASS_SP_NAME_TO_EVENT = "passSPNameToEvent";
 
     public static final String SCREEN_VALUE = "&screenValue=";
+    public static final String ERROR_TOKEN_EXPIRED = "&authFailure=true&authFailureMsg=token.expired";
     public static final String SHOW_EMAIL_ADDRESS_IN_UI = "showEmailAddressInUI";
     public static final String EMAIL_ADDRESS_REGEX = "emailAddressRegex";
     public static final String USE_EVENT_HANDLER_BASED_EMAIL_SENDER = "useEventHandlerBasedEmailSender";

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
@@ -128,6 +128,7 @@ public class EmailOTPAuthenticatorConstants {
     public static final String PASS_SP_NAME_TO_EVENT = "passSPNameToEvent";
 
     public static final String SCREEN_VALUE = "&screenValue=";
+    public static final String ERROR_TOKEN_EXPIRED_EMAIL_SENT = "&authFailure=true&authFailureMsg=token.expired.email.sent";
     public static final String ERROR_TOKEN_EXPIRED = "&authFailure=true&authFailureMsg=token.expired";
     public static final String SHOW_EMAIL_ADDRESS_IN_UI = "showEmailAddressInUI";
     public static final String EMAIL_ADDRESS_REGEX = "emailAddressRegex";


### PR DESCRIPTION
### Purpose

Redirect URL has been built with the query param `&authFailure=true&authFailureMsg=token.expired` whenever a user enters an OTP after the OTP has been expired

### Related Issue
- https://github.com/wso2/product-is/issues/15541