### PR TITLE
Remove SHA1 default usage 

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
@@ -31,9 +31,9 @@ public class EmailOTPAuthenticatorConstants {
     public static final String AUTHENTICATOR_NAME = "EmailOTP";
     public static final String AUTHENTICATOR_FRIENDLY_NAME = "Email OTP";
 
-    public static final String ALGORITHM_NAME = "SHA1PRNG";
-    public static final String ALGORITHM_HMAC = "HmacSHA1";
-    public static final String ALGORITHM_HMAC_SHA = "HMAC-SHA-1";
+    public static final String ALGORITHM_NAME = "DRBG";
+    public static final String ALGORITHM_HMAC = "HmacSHA256";
+    public static final String ALGORITHM_HMAC_SHA = "HMAC-SHA-256";
     public static final int SECRET_KEY_LENGTH = 5;
     public static final int NUMBER_BASE = 2;
     public static final int NUMBER_DIGIT = 6;

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/OneTimePassword.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/OneTimePassword.java
@@ -78,12 +78,13 @@ public class OneTimePassword {
 
     /**
      * This method uses the JCE to provide the HMAC-SHA-1 algorithm. HMAC computes a Hashed Message Authentication
-     * Code and in this case SHA1 is the hash algorithm used.
+     * Code and in this case SHA256 is the hash algorithm used.
      *
      * @param keyBytes The bytes to use for the HMAC-SHA-1 key.
      * @param text     The message or text to be authenticated.
-     * @throws NoSuchAlgorithmException If no provider makes either HmacSHA1 or HMAC-SHA-1 digest algorithms available.
-     * @throws InvalidKeyException      The secret provided was not a valid HMAC-SHA-1 key.
+     * @throws NoSuchAlgorithmException If no provider makes either HmacSHA256 or HMAC-SHA-256 digest algorithms
+     * available.
+     * @throws InvalidKeyException      The secret provided was not a valid HMAC-SHA-256 key.
      */
     public static byte[] hmacShaGenerate(byte[] keyBytes, byte[] text)
             throws NoSuchAlgorithmException, InvalidKeyException {
@@ -109,7 +110,8 @@ public class OneTimePassword {
      * @param truncationOffset The offset into the MAC result to begin truncation. If this value is out of the range
      *                         of 0 ... 15, then dynamic truncation will be used. Dynamic truncation is when the last
      *                         4 bits of the last byte of the MAC are used to determine the start offset.
-     * @throws NoSuchAlgorithmException If no provider makes either HmacSHA1 or HMAC-SHA-1 digest algorithms available.
+     * @throws NoSuchAlgorithmException If no provider makes either HmacSHA256 or HMAC-SHA-256 digest algorithms
+     * available.
      * @throws InvalidKeyException      The secret provided was not a valid HMAC-SHA-1 key.
      */
     public static String generateOTP(byte[] secret, long movingFactor, int codeDigits, boolean addChecksum,

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorTest.java
@@ -246,7 +246,7 @@ public class EmailOTPAuthenticatorTest {
         emailOTPAuthenticator = PowerMockito.spy(new EmailOTPAuthenticator());
         // Mocking the random number generation since algorithm DRBG is not supported in java 8. Revert this when
         // source is compatible with java 11.
-        when(OneTimePassword.getRandomNumber(EmailOTPAuthenticatorConstants.SECRET_KEY_LENGTH)).thenReturn("12345");
+        when(OneTimePassword.getRandomNumber(EmailOTPAuthenticatorConstants.SECRET_KEY_LENGTH)).thenReturn("123456");
         doNothing().when(emailOTPAuthenticator, "sendOTP", anyString(), anyString(), anyString(), anyObject(),
                 anyString());
         AuthenticatorFlowStatus status = emailOTPAuthenticator.process(httpServletRequest, httpServletResponse,
@@ -280,7 +280,7 @@ public class EmailOTPAuthenticatorTest {
         emailOTPAuthenticator = PowerMockito.spy(new EmailOTPAuthenticator());
         // Mocking the random number generation since algorithm DRBG is not supported in java 8. Revert this when
         // source is compatible with java 11.
-        when(OneTimePassword.getRandomNumber(EmailOTPAuthenticatorConstants.SECRET_KEY_LENGTH)).thenReturn("12345");
+        when(OneTimePassword.getRandomNumber(EmailOTPAuthenticatorConstants.SECRET_KEY_LENGTH)).thenReturn("123456");
         doNothing().when(emailOTPAuthenticator, "sendOTP", anyString(), anyString(), anyString(), anyObject(),
                 anyString());
         AuthenticatorFlowStatus status = emailOTPAuthenticator.process(httpServletRequest, httpServletResponse,
@@ -322,7 +322,7 @@ public class EmailOTPAuthenticatorTest {
                 .thenReturn(EmailOTPAuthenticatorTestConstants.EMAIL_ADDRESS);
         // Mocking the random number generation since algorithm DRBG is not supported in java 8. Revert this when
         // source is compatible with java 11.
-        when(OneTimePassword.getRandomNumber(EmailOTPAuthenticatorConstants.SECRET_KEY_LENGTH)).thenReturn("12345");
+        when(OneTimePassword.getRandomNumber(EmailOTPAuthenticatorConstants.SECRET_KEY_LENGTH)).thenReturn("123456");
         emailOTPAuthenticator = PowerMockito.spy(new EmailOTPAuthenticator());
         doNothing().when(emailOTPAuthenticator, "sendOTP", anyString(), anyString(), anyString(), anyObject(),
                 anyString());
@@ -365,7 +365,7 @@ public class EmailOTPAuthenticatorTest {
                 .thenReturn(EmailOTPAuthenticatorTestConstants.EMAIL_ADDRESS);
         // Mocking the random number generation since algorithm DRBG is not supported in java 8. Revert this when
         // source is compatible with java 11.
-        when(OneTimePassword.getRandomNumber(EmailOTPAuthenticatorConstants.SECRET_KEY_LENGTH)).thenReturn("12345");
+        when(OneTimePassword.getRandomNumber(EmailOTPAuthenticatorConstants.SECRET_KEY_LENGTH)).thenReturn("123456");
         emailOTPAuthenticator = PowerMockito.spy(new EmailOTPAuthenticator());
         doNothing().when(emailOTPAuthenticator, "sendOTP", anyString(), anyString(), anyString(), anyObject(),
                 anyString());
@@ -474,7 +474,7 @@ public class EmailOTPAuthenticatorTest {
         emailOTPAuthenticator = PowerMockito.spy(new EmailOTPAuthenticator());
         // Mocking the random number generation since algorithm DRBG is not supported in java 8. Revert this when
         // source is compatible with java 11.
-        when(OneTimePassword.getRandomNumber(EmailOTPAuthenticatorConstants.SECRET_KEY_LENGTH)).thenReturn("12345");
+        when(OneTimePassword.getRandomNumber(EmailOTPAuthenticatorConstants.SECRET_KEY_LENGTH)).thenReturn("123456");
         doNothing().when(emailOTPAuthenticator, "sendOTP", anyString(), anyString(), anyString(), anyObject(),
                 anyString());
         AuthenticatorFlowStatus status = emailOTPAuthenticator.process(httpServletRequest, httpServletResponse,
@@ -510,7 +510,7 @@ public class EmailOTPAuthenticatorTest {
         mockFederatedEmailAttributeKey(parameters, authenticatedUser, EmailOTPAuthenticatorTestConstants.EMAIL_ADDRESS);
         // Mocking the random number generation since algorithm DRBG is not supported in java 8. Revert this when
         // source is compatible with java 11.
-        when(OneTimePassword.getRandomNumber(EmailOTPAuthenticatorConstants.SECRET_KEY_LENGTH)).thenReturn("12345");
+        when(OneTimePassword.getRandomNumber(EmailOTPAuthenticatorConstants.SECRET_KEY_LENGTH)).thenReturn("123456");
         emailOTPAuthenticator = PowerMockito.spy(new EmailOTPAuthenticator());
         doNothing().when(emailOTPAuthenticator, "sendOTP", anyString(), anyString(), anyString(), anyObject(),
                 anyString());

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorTest.java
@@ -87,7 +87,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @PrepareForTest({EmailOTPAuthenticator.class, FileBasedConfigurationBuilder.class, FederatedAuthenticatorUtil.class,
         FrameworkUtils.class, MultitenantUtils.class, IdentityTenantUtil.class, ConfigurationContextFactory.class,
         ConfigBuilder.class, NotificationBuilder.class, EmailOTPUtils.class, EmailOTPServiceDataHolder.class,
-        ServiceURLBuilder.class, AbstractUserStoreManager.class})
+        ServiceURLBuilder.class, AbstractUserStoreManager.class, OneTimePassword.class})
 @PowerMockIgnore({"javax.crypto.*"})
 public class EmailOTPAuthenticatorTest {
     private EmailOTPAuthenticator emailOTPAuthenticator;
@@ -136,6 +136,7 @@ public class EmailOTPAuthenticatorTest {
         mockStatic(ConfigBuilder.class);
         mockStatic(NotificationBuilder.class);
         mockStatic(EmailOTPUtils.class);
+        mockStatic(OneTimePassword.class);
 
         EmailOTPServiceDataHolder emailOTPServiceDataHolder = mock(EmailOTPServiceDataHolder.class);
         IdentityEventService identityEventService = mock(IdentityEventService.class);
@@ -243,6 +244,9 @@ public class EmailOTPAuthenticatorTest {
                 EmailOTPAuthenticatorConstants.EMAIL_CLAIM, null))
                 .thenReturn(EmailOTPAuthenticatorTestConstants.EMAIL_ADDRESS);
         emailOTPAuthenticator = PowerMockito.spy(new EmailOTPAuthenticator());
+        // Mocking the random number generation since algorithm DRBG is not supported in java 8. Revert this when
+        // source is compatible with java 11.
+        when(OneTimePassword.getRandomNumber(EmailOTPAuthenticatorConstants.SECRET_KEY_LENGTH)).thenReturn("12345");
         doNothing().when(emailOTPAuthenticator, "sendOTP", anyString(), anyString(), anyString(), anyObject(),
                 anyString());
         AuthenticatorFlowStatus status = emailOTPAuthenticator.process(httpServletRequest, httpServletResponse,
@@ -274,6 +278,9 @@ public class EmailOTPAuthenticatorTest {
                 EmailOTPAuthenticatorConstants.EMAIL_CLAIM, null))
                 .thenReturn(EmailOTPAuthenticatorTestConstants.EMAIL_ADDRESS);
         emailOTPAuthenticator = PowerMockito.spy(new EmailOTPAuthenticator());
+        // Mocking the random number generation since algorithm DRBG is not supported in java 8. Revert this when
+        // source is compatible with java 11.
+        when(OneTimePassword.getRandomNumber(EmailOTPAuthenticatorConstants.SECRET_KEY_LENGTH)).thenReturn("12345");
         doNothing().when(emailOTPAuthenticator, "sendOTP", anyString(), anyString(), anyString(), anyObject(),
                 anyString());
         AuthenticatorFlowStatus status = emailOTPAuthenticator.process(httpServletRequest, httpServletResponse,
@@ -313,6 +320,9 @@ public class EmailOTPAuthenticatorTest {
         when(userStoreManager.getUserClaimValue(EmailOTPAuthenticatorTestConstants.USER_NAME,
                 EmailOTPAuthenticatorConstants.EMAIL_CLAIM, null))
                 .thenReturn(EmailOTPAuthenticatorTestConstants.EMAIL_ADDRESS);
+        // Mocking the random number generation since algorithm DRBG is not supported in java 8. Revert this when
+        // source is compatible with java 11.
+        when(OneTimePassword.getRandomNumber(EmailOTPAuthenticatorConstants.SECRET_KEY_LENGTH)).thenReturn("12345");
         emailOTPAuthenticator = PowerMockito.spy(new EmailOTPAuthenticator());
         doNothing().when(emailOTPAuthenticator, "sendOTP", anyString(), anyString(), anyString(), anyObject(),
                 anyString());
@@ -353,6 +363,9 @@ public class EmailOTPAuthenticatorTest {
         when(userStoreManager.getUserClaimValue(EmailOTPAuthenticatorTestConstants.USER_NAME,
                 EmailOTPAuthenticatorConstants.EMAIL_CLAIM, null))
                 .thenReturn(EmailOTPAuthenticatorTestConstants.EMAIL_ADDRESS);
+        // Mocking the random number generation since algorithm DRBG is not supported in java 8. Revert this when
+        // source is compatible with java 11.
+        when(OneTimePassword.getRandomNumber(EmailOTPAuthenticatorConstants.SECRET_KEY_LENGTH)).thenReturn("12345");
         emailOTPAuthenticator = PowerMockito.spy(new EmailOTPAuthenticator());
         doNothing().when(emailOTPAuthenticator, "sendOTP", anyString(), anyString(), anyString(), anyObject(),
                 anyString());
@@ -459,6 +472,9 @@ public class EmailOTPAuthenticatorTest {
         setStepConfigWithFederatedAuthenticator(authenticatedUser, authenticatorConfig);
         mockFederatedEmailAttributeKey(parameters, authenticatedUser, EmailOTPAuthenticatorTestConstants.EMAIL_ADDRESS);
         emailOTPAuthenticator = PowerMockito.spy(new EmailOTPAuthenticator());
+        // Mocking the random number generation since algorithm DRBG is not supported in java 8. Revert this when
+        // source is compatible with java 11.
+        when(OneTimePassword.getRandomNumber(EmailOTPAuthenticatorConstants.SECRET_KEY_LENGTH)).thenReturn("12345");
         doNothing().when(emailOTPAuthenticator, "sendOTP", anyString(), anyString(), anyString(), anyObject(),
                 anyString());
         AuthenticatorFlowStatus status = emailOTPAuthenticator.process(httpServletRequest, httpServletResponse,
@@ -492,6 +508,9 @@ public class EmailOTPAuthenticatorTest {
                 .thenReturn(null);
         setStepConfigWithFederatedAuthenticator(authenticatedUser, authenticatorConfig);
         mockFederatedEmailAttributeKey(parameters, authenticatedUser, EmailOTPAuthenticatorTestConstants.EMAIL_ADDRESS);
+        // Mocking the random number generation since algorithm DRBG is not supported in java 8. Revert this when
+        // source is compatible with java 11.
+        when(OneTimePassword.getRandomNumber(EmailOTPAuthenticatorConstants.SECRET_KEY_LENGTH)).thenReturn("12345");
         emailOTPAuthenticator = PowerMockito.spy(new EmailOTPAuthenticator());
         doNothing().when(emailOTPAuthenticator, "sendOTP", anyString(), anyString(), anyString(), anyObject(),
                 anyString());

--- a/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/constant/Constants.java
+++ b/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/constant/Constants.java
@@ -27,9 +27,9 @@ import java.util.List;
  */
 public class Constants {
 
-    public static final String ALGORITHM_NAME = "SHA1PRNG";
-    public static final String ALGORITHM_HMAC = "HmacSHA1";
-    public static final String ALGORITHM_HMAC_SHA = "HMAC-SHA-1";
+    public static final String ALGORITHM_NAME = "DRBG";
+    public static final String ALGORITHM_HMAC = "HmacSHA256";
+    public static final String ALGORITHM_HMAC_SHA = "HMAC-SHA-256";
     public static final String SESSION_TYPE_OTP = "EMAIL_OTP";
     public static final String NOTIFICATION_TYPE_EMAIL_OTP = "EmailOTP";
     public static final String OTP_CODE = "OTPCode";

--- a/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/util/OneTimePasswordUtils.java
+++ b/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/util/OneTimePasswordUtils.java
@@ -92,16 +92,16 @@ public class OneTimePasswordUtils {
     }
 
     /**
-     * This method uses the JCE to provide the HMAC-SHA-1
+     * This method uses the JCE to provide the HMAC-SHA-256
      * algorithm. HMAC computes a Hashed Message Authentication Code and in this
-     * case SHA1 is the hash algorithm used.
+     * case SHA256 is the hash algorithm used.
      *
-     * @param keyBytes Bytes to use for the HMAC-SHA-1 key.
+     * @param keyBytes Bytes to use for the HMAC-SHA-256 key.
      * @param text     Message or text to be authenticated.
      * @return Generated HMAC-SHA byte array.
-     * @throws NoSuchAlgorithmException If no provider makes either HmacSHA1 or HMAC-SHA-1 digest
+     * @throws NoSuchAlgorithmException If no provider makes either HmacSHA256 or HMAC-SHA-256 digest
      *                                  algorithms available.
-     * @throws InvalidKeyException      The secret provided was not a valid HMAC-SHA-1 key.
+     * @throws InvalidKeyException      The secret provided was not a valid HMAC-SHA-256 key.
      */
     public static byte[] hmacShaGenerate(byte[] keyBytes, byte[] text) throws NoSuchAlgorithmException,
             InvalidKeyException {
@@ -133,9 +133,9 @@ public class OneTimePasswordUtils {
      *                         the last byte of the MAC are used to determine the start
      *                         offset.
      * @return Generated OTP.
-     * @throws NoSuchAlgorithmException If no provider makes either HmacSHA1 or HMAC-SHA-1 digest
+     * @throws NoSuchAlgorithmException If no provider makes either HmacSHA256 or HMAC-SHA-256 digest
      *                                  algorithms available.
-     * @throws InvalidKeyException      The secret provided was not a valid HMAC-SHA-1 key.
+     * @throws InvalidKeyException      The secret provided was not a valid HMAC-SHA-256 key.
      */
     public static String generateOTP(byte[] secret, long movingFactor, int codeDigits, boolean addChecksum,
                                      int truncationOffset) throws NoSuchAlgorithmException, InvalidKeyException {
@@ -185,9 +185,9 @@ public class OneTimePasswordUtils {
      *                         the last byte of the MAC are used to determine the start
      *                         offset.
      * @return Generate alpha numeric OTP.
-     * @throws NoSuchAlgorithmException If no provider makes either HmacSHA1 or HMAC-SHA-1 digest
+     * @throws NoSuchAlgorithmException If no provider makes either HmacSHA256 or HMAC-SHA-256 digest
      *                                  algorithms available.
-     * @throws InvalidKeyException      The secret provided was not a valid HMAC-SHA-1 key.
+     * @throws InvalidKeyException      The secret provided was not a valid HMAC-SHA-256 key.
      */
     public static String generateAlphaNumericOTP(byte[] secret, long movingFactor, int codeDigits, boolean addChecksum,
                                                  int truncationOffset)
@@ -238,7 +238,7 @@ public class OneTimePasswordUtils {
                 return generateAlphaNumericOTP(key.getBytes(), Long.parseLong(base), length, false, truncOffset);
             } catch (NoSuchAlgorithmException e) {
                 throw Utils.handleServerException(Constants.ErrorMessage.SERVER_GENERATE_ALPHA_NUMERIC_OTP_ERROR,
-                        "Unable to find the SHA1 Algorithm to generate OTP.", e);
+                        "Unable to find the SHA256 Algorithm to generate OTP.", e);
             } catch (InvalidKeyException e) {
                 throw Utils.handleServerException(Constants.ErrorMessage.SERVER_GENERATE_ALPHA_NUMERIC_OTP_ERROR,
                         "Unable to find the secret key.", e);
@@ -248,7 +248,7 @@ public class OneTimePasswordUtils {
                 return generateOTP(key.getBytes(), Long.parseLong(base), length, false, truncOffset);
             } catch (NoSuchAlgorithmException e) {
                 throw Utils.handleServerException(Constants.ErrorMessage.SERVER_GENERATE_OTP_ERROR,
-                        "Unable to find the SHA1 Algorithm to generate OTP.", e);
+                        "Unable to find the SHA256 Algorithm to generate OTP.", e);
             } catch (InvalidKeyException e) {
                 throw Utils.handleServerException(Constants.ErrorMessage.SERVER_GENERATE_OTP_ERROR,
                         "Unable to find the secret key.", e);

--- a/component/common/src/test/java/org/wso2/carbon/identity/extension/emailotp/common/test/OneTimePasswordUtilsTest.java
+++ b/component/common/src/test/java/org/wso2/carbon/identity/extension/emailotp/common/test/OneTimePasswordUtilsTest.java
@@ -88,7 +88,7 @@ public class OneTimePasswordUtilsTest {
                 String.valueOf(Constants.NUMBER_BASE),
                 Constants.DEFAULT_OTP_LENGTH,
                 false),
-                "900361");
+                "673418");
     }
 
     @Test
@@ -100,6 +100,6 @@ public class OneTimePasswordUtilsTest {
                 String.valueOf(Constants.NUMBER_BASE),
                 Constants.DEFAULT_OTP_LENGTH,
                 true),
-                "W5GG7P");
+                "2B0A7V");
     }
 }


### PR DESCRIPTION
## Proposed changes in this pull request

The default behavior of our products uses SHA1 which is no longer considered as secure. This PR changes the default usage to SHA256 in the following flows.
- Random number will be generated using DRBG algorithm instead of SHA1PRNG.
- OTP will be generated using HMACSHA256.

## Related issues
 
- Issue https://github.com/wso2/product-is/issues/15793

## Related PRs

- PR https://github.com/wso2/carbon-identity-framework/pull/4567
- PR https://github.com/wso2-extensions/identity-outbound-auth-samlsso/pull/162
- PR https://github.com/wso2-extensions/identity-inbound-auth-sts/pull/136
- PR https://github.com/wso2-extensions/identity-metadata-saml2/pull/85
- PR https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2076
- PR https://github.com/wso2/cipher-tool/pull/78
- PR https://github.com/wso2/carbon-kernel/pull/3574
- PR https://github.com/wso2-extensions/identity-user-account-association/pull/47
- PR https://github.com/wso2-enterprise/asgardeo-website/pull/639
- PR https://github.com/wso2-extensions/identity-governance/pull/707
- PR https://github.com/wso2-extensions/identity-inbound-auth-openid/pull/92
- PR https://github.com/wso2-extensions/identity-outbound-auth-sms-otp/pull/173

## Documentation

- PR https://github.com/wso2/docs-is/pull/3717

