### PR TITLE
Improve Email OTP authenticator to send init IDF query param

### DIFF
--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -246,5 +246,10 @@
             <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
             <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.multi.attribute.login.mgt</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -46,6 +46,7 @@ import org.wso2.carbon.identity.application.authentication.framework.exception.L
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedIdPData;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.Property;
@@ -2847,9 +2848,12 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
             redirectUrl.append(queryParams);
             redirectUrl.append("&");
             redirectUrl.append(EmailOTPAuthenticatorConstants.AUTHENTICATORS);
-            redirectUrl.append(EmailOTPAuthenticatorConstants.IDF_HANDLER_NAME);
+            redirectUrl.append(EmailOTPAuthenticatorConstants.AUTHENTICATOR_NAME);
             redirectUrl.append(":");
             redirectUrl.append(EmailOTPAuthenticatorConstants.LOCAL_AUTHENTICATOR);
+            redirectUrl.append("&");
+            redirectUrl.append(FrameworkConstants.RequestParams.INITIATE_IDENTIFIER_FIRST);
+            redirectUrl.append("=true");
             response.sendRedirect(redirectUrl.toString());
         } catch (IOException e) {
             throw new AuthenticationFailedException("Error while redirecting to the login page.", e);

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorTest.java
@@ -67,6 +67,7 @@ import org.wso2.carbon.identity.mgt.config.StorageType;
 import org.wso2.carbon.identity.mgt.mail.Notification;
 import org.wso2.carbon.identity.mgt.mail.NotificationBuilder;
 import org.wso2.carbon.identity.mgt.mail.NotificationData;
+import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
 import org.wso2.carbon.user.api.Claim;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
@@ -140,6 +141,7 @@ public class EmailOTPAuthenticatorTest {
     private HashMap<String, TransportOutDescription> transportOutDescriptionHashMap;
     private Notification notification;
     private FrameworkServiceDataHolder frameworkServiceDataHolder;
+    private MultiAttributeLoginService multiAttributeLoginService;
 
     @BeforeMethod
     public void setUp() throws Exception {
@@ -167,6 +169,7 @@ public class EmailOTPAuthenticatorTest {
         config = mock(Config.class);
         notification = mock(Notification.class);
         frameworkServiceDataHolder = mock(FrameworkServiceDataHolder.class);
+        multiAttributeLoginService = mock(MultiAttributeLoginService.class);
 
         mockStatic(FileBasedConfigurationBuilder.class);
         mockStatic(EmailOTPServiceDataHolder.class);
@@ -294,6 +297,9 @@ public class EmailOTPAuthenticatorTest {
             .thenReturn(
                 USER_NAME + "@" + EmailOTPAuthenticatorConstants.SUPER_TENANT);
         mockUserRealm();
+        when(frameworkServiceDataHolder.getMultiAttributeLoginService()).thenReturn(multiAttributeLoginService);
+        when(multiAttributeLoginService.isEnabled(anyString())).thenReturn(false);
+
         User user = new User(UUID.randomUUID().toString(), USER_NAME, null);
         user.setUserStoreDomain("PRIMARY");
         user.setTenantDomain(EmailOTPAuthenticatorConstants.SUPER_TENANT);
@@ -342,6 +348,8 @@ public class EmailOTPAuthenticatorTest {
         when(MultitenantUtils.getTenantDomain(anyString())).thenReturn(TENANT_DOMAIN);
         when(FederatedAuthenticatorUtil.isUserExistInUserStore(anyString())).thenReturn(false);
         mockUserRealm();
+        when(frameworkServiceDataHolder.getMultiAttributeLoginService()).thenReturn(multiAttributeLoginService);
+        when(multiAttributeLoginService.isEnabled(anyString())).thenReturn(false);
         when(userStoreManager.getUserListWithID(USERNAME_CLAIM, USER_NAME, null))
                 .thenReturn(new ArrayList<User>());
 

--- a/pom.xml
+++ b/pom.xml
@@ -364,6 +364,12 @@
                 <version>${identity.organization.management.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.multi.attribute.login.mgt</artifactId>
+                <version>${carbon.identity.version}</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -483,7 +489,7 @@
     </distributionManagement>
 
     <properties>
-        <carbon.identity.version>5.25.204</carbon.identity.version>
+        <carbon.identity.version>5.25.259-SNAPSHOT</carbon.identity.version>
         <carbon.identity.event.version>5.18.209</carbon.identity.event.version>
         <commons-logging.version>4.4.3</commons-logging.version>
         <carbon.kernel.version>4.7.0</carbon.kernel.version>


### PR DESCRIPTION
**Purpose**
Email OTP authenticator supports first factor login. That is through the self-contained IDF improvement. In there we have the user resolving logic at the authenticator, however the user identifier is retrieved using the Identifier first frontend code. This is done with the `authenticators` request parameter passed with the value of `IdentifierExecutor:LOCAL`. Due to this some flows recognize this as IDF being in the authentication sequence and raise issues.

This PR fixes it by removing the `IdentifierExecutor:LOCAL` value from the authenticators parameter and introducing a new query parameter to trigger the IDF frontend.

*Related Issue*
- https://github.com/wso2/product-is/issues/16321

**Related PRs**
- https://github.com/wso2/carbon-identity-framework/pull/4812
