### PR TITLE
Checking the user is resolved from a previous step

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -145,7 +145,6 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
         } else if (StringUtils.isEmpty(request.getParameter(EmailOTPAuthenticatorConstants.CODE)) &&
                 StringUtils.isEmpty(request.getParameter(EmailOTPAuthenticatorConstants.RESEND))) {
             AuthenticatedUser authenticatedUser = getAuthenticatedUser(context);
-            boolean isUserResolved = getIsUserResolved(context);
             if (authenticatedUser == null) {
                 if (StringUtils.isEmpty(request.getParameter(EmailOTPAuthenticatorConstants.USER_NAME))) {
                     redirectUserToIDF(response, context);
@@ -157,6 +156,7 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
                     setResolvedUserInContext(context, authenticatedUser);
                 }
             } else if (isPreviousIdPAuthenticationFlowHandler(context)) {
+                boolean isUserResolved = getIsUserResolved(context);
                 // Resolve the user from user store if the user is not resolved in IDF handler.
                 if (!isUserResolved) {
                     authenticatedUser = resolveUserFromUserStore(authenticatedUser);

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -156,7 +156,7 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
                     setResolvedUserInContext(context, authenticatedUser);
                 }
             } else if (isPreviousIdPAuthenticationFlowHandler(context)) {
-                boolean isUserResolved = getIsUserResolved(context);
+                boolean isUserResolved = FrameworkUtils.getIsUserResolved(context);
                 // Resolve the user from user store if the user is not resolved in IDF handler.
                 if (!isUserResolved) {
                     authenticatedUser = resolveUserFromUserStore(authenticatedUser);
@@ -3016,20 +3016,5 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
     private boolean isEmailOTPAsFirstFactor(AuthenticationContext context) {
 
         return (context.getCurrentStep() == 1 || isPreviousIdPAuthenticationFlowHandler(context));
-    }
-
-    /**
-     * This method is to check whether the user is resolved or not.
-     * @param context
-     * @return true if the user is resolved, false otherwise.
-     */
-    private boolean getIsUserResolved(AuthenticationContext context) {
-
-        boolean isUserResolved = false;
-        if (!context.getProperties().isEmpty() &&
-                context.getProperty(EmailOTPAuthenticatorConstants.IS_USER_RESOLVED) != null) {
-            isUserResolved = (boolean) context.getProperty(EmailOTPAuthenticatorConstants.IS_USER_RESOLVED);
-        }
-        return isUserResolved;
     }
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -2915,6 +2915,8 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
             }
             authenticatedUser = new AuthenticatedUser(user);
             authenticatedUser.setAuthenticatedSubjectIdentifier(user.getUsername());
+        } else {
+            authenticatedUser.setAuthenticatedSubjectIdentifier(authenticatedUser.getUserName());
         }
         return authenticatedUser;
     }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -2906,34 +2906,13 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
                                                        AuthenticationContext context)
             throws AuthenticationFailedException {
 
-        boolean isUserResolved = getIsUserResolved(context);
-        // If user is not resolved from a previous step, resolve the user from the user store.
-        if (!isUserResolved) {
-            User user = getUser(authenticatedUser);
-            if (user == null) {
-                return null;
-            }
-            authenticatedUser = new AuthenticatedUser(user);
-            authenticatedUser.setAuthenticatedSubjectIdentifier(user.getUsername());
-        } else {
-            authenticatedUser.setAuthenticatedSubjectIdentifier(authenticatedUser.getUserName());
+        User user = getUser(authenticatedUser, context);
+        if (user == null) {
+            return null;
         }
+        authenticatedUser = new AuthenticatedUser(user);
+        authenticatedUser.setAuthenticatedSubjectIdentifier(user.getUsername());
         return authenticatedUser;
-    }
-
-    /**
-     * This method is to check that user is already resolved from previous steps.
-     * @param context
-     * @return true if user is already resolved.
-     */
-    private boolean getIsUserResolved(AuthenticationContext context) {
-
-        boolean isUserResolved = false;
-        if (!context.getProperties().isEmpty() &&
-                context.getProperty(EmailOTPAuthenticatorConstants.IS_USER_RESOLVED) != null) {
-            isUserResolved = (boolean) context.getProperty(EmailOTPAuthenticatorConstants.IS_USER_RESOLVED);
-        }
-        return isUserResolved;
     }
 
     /**

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
@@ -46,6 +46,8 @@ public class EmailOTPAuthenticatorConstants {
     public static final String API_GMAIL = "Gmail";
     public static final String API_SENDGRID = "Sendgrid";
 
+    public static final String IS_USER_RESOLVED = "isUserResolved";
+
     public static final String CLIENT_ID = "ClientId";
     public static final String CLIENT_SECRET = "ClientSecret";
     public static final String CODE = "OTPCode";

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
@@ -152,6 +152,8 @@ public class EmailOTPAuthenticatorConstants {
     public static final String STATUS_CODE_MISMATCH = "code-mismatch";
     public static final String TRUE = "true";
 
+    public static final String IS_USER_RESOLVED = "isUserResolved";
+
     // Account lock related constants.
     public static final String EMAIL_OTP_FAILED_ATTEMPTS_CLAIM =
             "http://wso2.org/claims/identity/failedEmailOtpAttempts";

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
@@ -46,8 +46,6 @@ public class EmailOTPAuthenticatorConstants {
     public static final String API_GMAIL = "Gmail";
     public static final String API_SENDGRID = "Sendgrid";
 
-    public static final String IS_USER_RESOLVED = "isUserResolved";
-
     public static final String CLIENT_ID = "ClientId";
     public static final String CLIENT_SECRET = "ClientSecret";
     public static final String CODE = "OTPCode";

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
@@ -152,8 +152,6 @@ public class EmailOTPAuthenticatorConstants {
     public static final String STATUS_CODE_MISMATCH = "code-mismatch";
     public static final String TRUE = "true";
 
-    public static final String IS_USER_RESOLVED = "isUserResolved";
-
     // Account lock related constants.
     public static final String EMAIL_OTP_FAILED_ATTEMPTS_CLAIM =
             "http://wso2.org/claims/identity/failedEmailOtpAttempts";

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorTest.java
@@ -67,6 +67,7 @@ import org.wso2.carbon.identity.mgt.config.StorageType;
 import org.wso2.carbon.identity.mgt.mail.Notification;
 import org.wso2.carbon.identity.mgt.mail.NotificationBuilder;
 import org.wso2.carbon.identity.mgt.mail.NotificationData;
+import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
 import org.wso2.carbon.user.api.Claim;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
@@ -140,6 +141,7 @@ public class EmailOTPAuthenticatorTest {
     private HashMap<String, TransportOutDescription> transportOutDescriptionHashMap;
     private Notification notification;
     private FrameworkServiceDataHolder frameworkServiceDataHolder;
+    private MultiAttributeLoginService multiAttributeLoginService;
 
     @BeforeMethod
     public void setUp() throws Exception {
@@ -167,6 +169,7 @@ public class EmailOTPAuthenticatorTest {
         config = mock(Config.class);
         notification = mock(Notification.class);
         frameworkServiceDataHolder = mock(FrameworkServiceDataHolder.class);
+        multiAttributeLoginService = mock(MultiAttributeLoginService.class);
 
         mockStatic(FileBasedConfigurationBuilder.class);
         mockStatic(EmailOTPServiceDataHolder.class);
@@ -299,6 +302,7 @@ public class EmailOTPAuthenticatorTest {
         user.setTenantDomain(EmailOTPAuthenticatorConstants.SUPER_TENANT);
         List<User> userList = new ArrayList<>();
         userList.add(user);
+        mockMultiAttributeLoginService();
         when(userStoreManager.getUserListWithID(USERNAME_CLAIM, USER_NAME, null)).thenReturn(userList);
         mockSendOTP();
 
@@ -342,6 +346,7 @@ public class EmailOTPAuthenticatorTest {
         when(MultitenantUtils.getTenantDomain(anyString())).thenReturn(TENANT_DOMAIN);
         when(FederatedAuthenticatorUtil.isUserExistInUserStore(anyString())).thenReturn(false);
         mockUserRealm();
+        mockMultiAttributeLoginService();
         when(userStoreManager.getUserListWithID(USERNAME_CLAIM, USER_NAME, null))
                 .thenReturn(new ArrayList<User>());
 
@@ -554,6 +559,12 @@ public class EmailOTPAuthenticatorTest {
         when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
         when(FrameworkServiceDataHolder.getInstance()).thenReturn(frameworkServiceDataHolder);
         when(frameworkServiceDataHolder.getRealmService()).thenReturn(realmService);
+    }
+
+    private void mockMultiAttributeLoginService() {
+        when(FrameworkServiceDataHolder.getInstance()).thenReturn(frameworkServiceDataHolder);
+        when(frameworkServiceDataHolder.getMultiAttributeLoginService()).thenReturn(multiAttributeLoginService);
+        when(multiAttributeLoginService.isEnabled(anyString())).thenReturn(false);
     }
 
     private void mockSendOTP() throws AxisFault, IdentityMgtConfigException, IdentityMgtServiceException {

--- a/pom.xml
+++ b/pom.xml
@@ -483,7 +483,7 @@
     </distributionManagement>
 
     <properties>
-        <carbon.identity.version>5.25.286</carbon.identity.version>
+        <carbon.identity.version>5.25.287</carbon.identity.version>
         <carbon.identity.event.version>5.18.209</carbon.identity.event.version>
         <commons-logging.version>4.4.3</commons-logging.version>
         <carbon.kernel.version>4.7.0</carbon.kernel.version>

--- a/pom.xml
+++ b/pom.xml
@@ -483,7 +483,7 @@
     </distributionManagement>
 
     <properties>
-        <carbon.identity.version>5.25.204</carbon.identity.version>
+        <carbon.identity.version>5.25.286</carbon.identity.version>
         <carbon.identity.event.version>5.18.209</carbon.identity.event.version>
         <commons-logging.version>4.4.3</commons-logging.version>
         <carbon.kernel.version>4.7.0</carbon.kernel.version>


### PR DESCRIPTION
## Purpose
- If IDF resolved the user from multi attribute login user resolving service, the `isUserResolved` property is set to true.
- This improvement is done to avoid user resolving again from the user store when the user is already resolved from the previous step.
- From this new changes, we only check for user when there is not `isUserResolved` in the context.


## This should be merge after 
https://github.com/wso2/carbon-identity-framework/pull/4860
