### PR TITLE
Add lockedReason and errorCode to account locked error url

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -1049,7 +1049,7 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
                     retryParam = EmailOTPAuthenticatorConstants.ERROR_USER_ACCOUNT_LOCKED;
                     // Locked reason.
                     String lockedReason = getLockedReason(authenticatedUser);
-                    if (StringUtils.isNotEmpty(lockedReason)) {
+                    if (StringUtils.isNotBlank(lockedReason)) {
                         queryParams += "&lockedReason=" + lockedReason;
                     }
                     queryParams += "&errorCode=" + UserCoreConstants.ErrorCode.USER_IS_LOCKED;


### PR DESCRIPTION
When a user is locked following parameters are added to the URL if `showAuthFailureReason` is enabled
```
errorCode: 17003
lockedReason: MAX_EMAIL_OTP_ATTEMPTS_EXCEEDED
authFailure: true
authFailureMsg: user.account.locked
unlockTime: <unlockTime>
```

Related issue https://github.com/wso2/product-is/issues/16333