### PR TITLE
Fix throwing exception when not local user

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -1045,7 +1045,7 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
                 Boolean.parseBoolean(emailOTPParameters.get(EmailOTPAuthenticatorConstants.SHOW_AUTH_FAILURE_REASON));
         AuthenticatedUser authenticatedUser = getAuthenticatedUser(context);
         try {
-            if (isLocalUser(context) && authenticatedUser != null && EmailOTPUtils.isAccountLocked(authenticatedUser)) {
+            if (isLocalUser(context) && EmailOTPUtils.isAccountLocked(authenticatedUser)) {
                 String retryParam;
                 if (showAuthFailureReason) {
                     long unlockTime = getUnlockTimeInMilliSeconds(authenticatedUser);

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -1045,11 +1045,7 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
                 Boolean.parseBoolean(emailOTPParameters.get(EmailOTPAuthenticatorConstants.SHOW_AUTH_FAILURE_REASON));
         AuthenticatedUser authenticatedUser = getAuthenticatedUser(context);
         try {
-            if (authenticatedUser == null) {
-                throw new AuthenticationFailedException("Authentication failed!. Cannot proceed further without " +
-                        "identifying the user");
-            }
-            if (isLocalUser(context) && EmailOTPUtils.isAccountLocked(authenticatedUser)) {
+            if (isLocalUser(context) && authenticatedUser != null && EmailOTPUtils.isAccountLocked(authenticatedUser)) {
                 String retryParam;
                 if (showAuthFailureReason) {
                     long unlockTime = getUnlockTimeInMilliSeconds(authenticatedUser);


### PR DESCRIPTION
Fix the bug introduced by https://github.com/wso2-extensions/identity-outbound-auth-email-otp/pull/164 where an exception can be thrown if isLocaluser() is false