### PR TITLE
Fix invalid tenant domain error

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -2706,7 +2706,7 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
             return;
         }
         Map<String, String> emailOTPParameters = getAuthenticatorConfig().getParameterMap();
-        String username = authenticatedUser.getAuthenticatedSubjectIdentifier();
+        String username = authenticatedUser.toFullQualifiedUsername();
         boolean isUserExist;
         try {
             isUserExist = FederatedAuthenticatorUtil.isUserExistInUserStore(username);


### PR DESCRIPTION
## Purpose
When trying to authenticate with email OTP (first factor or multi factor) with an email username when the email as username feature is disabled, getting invalid tenant domain error. Added this fix to get the tenant domain from authenticated user.

Related Issue - 
https://github.com/wso2/product-is/issues/16376

Related PRs -
https://github.com/wso2-extensions/identity-governance/pull/752