### PR TITLE
Validate user tenant domain and application tenant domain in non SaaS applications

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
@@ -111,8 +111,10 @@ public class EmailOTPAuthenticatorConstants {
 
     public static final String IS_EMAILOTP_MANDATORY = "EMAILOTPMandatory";
     public static final String EMAILOTP_AUTHENTICATION_ERROR_PAGE_URL = "EmailOTPAuthenticationEndpointErrorPage";
+    public static final String ERROR_AUTH_FAILURE_PREFIX = "&authFailure=true&authFailureMsg=";
     public static final String ERROR_EMAILOTP_DISABLE = "&authFailure=true&authFailureMsg=emailotp.disable";
     public static final String SEND_OTP_DIRECTLY_DISABLE = "&authFailure=true&authFailureMsg=directly.send.otp.disable";
+    public static final String ERROR_TENANT_MISMATCH_MSG = "user.tenant.domain.mismatch.message";
     public static final String BASIC = "basic";
     public static final String FEDERETOR = "federator";
     public static final String SEND_OTP_TO_FEDERATED_EMAIL_ATTRIBUTE = "sendOTPToFederatedEmailAttribute";

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorTest.java
@@ -40,6 +40,7 @@ import org.wso2.carbon.identity.application.authentication.framework.Authenticat
 import org.wso2.carbon.identity.application.authentication.framework.LocalApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.config.ConfigurationFacade;
 import org.wso2.carbon.identity.application.authentication.framework.config.builder.FileBasedConfigurationBuilder;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.ApplicationConfig;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.SequenceConfig;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.StepConfig;
@@ -51,6 +52,7 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Authe
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.authenticator.emailotp.config.EmailOTPUtils;
 import org.wso2.carbon.identity.authenticator.emailotp.internal.EmailOTPServiceDataHolder;
 import org.wso2.carbon.identity.core.ServiceURL;
@@ -1043,8 +1045,14 @@ public class EmailOTPAuthenticatorTest {
         emailOTPStep.setAuthenticatorList(authenticatorList);
         stepConfigMap.put(2, emailOTPStep);
 
+        ServiceProvider serviceProvider = new ServiceProvider();
+        serviceProvider.setSaasApp(false);
+        ApplicationConfig applicationConfig = new ApplicationConfig(serviceProvider,
+                EmailOTPAuthenticatorConstants.SUPER_TENANT);
+
         SequenceConfig sequenceConfig = new SequenceConfig();
         sequenceConfig.setStepMap(stepConfigMap);
+        sequenceConfig.setApplicationConfig(applicationConfig);
         context.setSequenceConfig(sequenceConfig);
         context.setCurrentStep(2);
     }


### PR DESCRIPTION
## Purpose
- Validate user tenant domain and application tenant domain in non SaaS applications for local users and add a context parameter. (Since Email OTP is a federated authenticator, this need to be handled at authenticator level)
- Handle the error page redirection if validation fails.