### PR TITLE
Change email OTP isNumeric checkbox to isAlphanumeric

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -1139,8 +1139,8 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
                     || (context.isRetrying() && !isOTPResendingDisabledOnFailure(context) && isOTPExpired(context))
                     || (context.isRetrying() && isEmailUpdateFailed(context))) {
 
-                boolean isCharInOTP = !Boolean.parseBoolean(authenticatorProperties
-                        .get(EmailOTPAuthenticatorConstants.EMAIL_OTP_NUMERIC_OTP));
+                boolean isCharInOTP = Boolean.parseBoolean(authenticatorProperties
+                    .get(EmailOTPAuthenticatorConstants.EMAIL_OTP_ALPHANUMERIC_OTP));
                 context.setProperty(EmailOTPAuthenticatorConstants.IS_CHAR_IN_OTP, isCharInOTP);
 
                 int expiryTime = getEmailOTPExpiryTime(authenticatorProperties);
@@ -2352,14 +2352,14 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
         expiryTimeOTP.setDisplayOrder(3);
         configProperties.add(expiryTimeOTP);
 
-        Property numericOTP = new Property();
-        numericOTP.setName(EmailOTPAuthenticatorConstants.EMAIL_OTP_NUMERIC_OTP);
-        numericOTP.setDisplayName("Use only numeric characters for OTP");
-        numericOTP.setDescription("Please clear this checkbox to enable alphanumeric characters.");
-        numericOTP.setDefaultValue("true");
-        numericOTP.setType("boolean");
-        numericOTP.setDisplayOrder(5);
-        configProperties.add(numericOTP);
+        Property alphaNumericOTP = new Property();
+        alphaNumericOTP.setName(EmailOTPAuthenticatorConstants.EMAIL_OTP_ALPHANUMERIC_OTP);
+        alphaNumericOTP.setDisplayName("Use alphanumeric characters for OTP");
+        alphaNumericOTP.setDescription("Please enter either 'true' or 'false' to enable alphanumeric characters or " +
+                "only numeric characters respectively. ");
+        alphaNumericOTP.setDefaultValue("false");
+        alphaNumericOTP.setDisplayOrder(4);
+        configProperties.add(alphaNumericOTP);
 
         return configProperties;
     }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -2355,11 +2355,18 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
         Property alphaNumericOTP = new Property();
         alphaNumericOTP.setName(EmailOTPAuthenticatorConstants.EMAIL_OTP_ALPHANUMERIC_OTP);
         alphaNumericOTP.setDisplayName("Use alphanumeric characters for OTP");
-        alphaNumericOTP.setDescription("Please enter either 'true' or 'false' to enable alphanumeric characters or " +
-                "only numeric characters respectively. ");
+        alphaNumericOTP.setDescription("Please check this checkbox to enable alphanumeric characters.");
         alphaNumericOTP.setDefaultValue("false");
+        alphaNumericOTP.setType("boolean");
         alphaNumericOTP.setDisplayOrder(4);
         configProperties.add(alphaNumericOTP);
+
+        Property numericOTP = new Property();
+        numericOTP.setName(EmailOTPAuthenticatorConstants.EMAIL_OTP_NUMERIC_OTP);
+        numericOTP.setDefaultValue("true");
+        numericOTP.setType("boolean");
+        numericOTP.setDisplayOrder(5);
+        configProperties.add(numericOTP);
 
         return configProperties;
     }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
@@ -177,6 +177,7 @@ public class EmailOTPAuthenticatorConstants {
     public static final String IDF_HANDLER_NAME = "IdentifierExecutor";
     public static final String USER = "user";
     public static final String EMAIL_OTP_ALPHANUMERIC_OTP = "AlphanumericCharactersForOtp";
+    public static final String EMAIL_OTP_NUMERIC_OTP = "OnlyNumericCharactersForOtp";
     public static final String IS_CHAR_IN_OTP = "IsCharInOTP";
     public static final String EMAIL_OTP_EXPIRY_TIME = "EmailOtpExpiryTime";
     public static final int EMAIL_OTP_MAX_EXPIRY_TIME = 1440;

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
@@ -176,7 +176,7 @@ public class EmailOTPAuthenticatorConstants {
     public static final String IS_IDF_INITIATED_FROM_AUTHENTICATOR = "isIdfInitiatedFromAuthenticator";
     public static final String IDF_HANDLER_NAME = "IdentifierExecutor";
     public static final String USER = "user";
-    public static final String EMAIL_OTP_NUMERIC_OTP = "OnlyNumericCharactersForOtp";
+    public static final String EMAIL_OTP_ALPHANUMERIC_OTP = "AlphanumericCharactersForOtp";
     public static final String IS_CHAR_IN_OTP = "IsCharInOTP";
     public static final String EMAIL_OTP_EXPIRY_TIME = "EmailOtpExpiryTime";
     public static final int EMAIL_OTP_MAX_EXPIRY_TIME = 1440;


### PR DESCRIPTION
## Purpose
> In the email OTP connector editing page, the check box is available to configure whether the OTP is numeric. Which is the default behaviour. The newly added feature is OTP as alphanumeric. Hence the config is getting changed to whether the OTP is alphanumeric.

Resolves
 - https://github.com/wso2/product-is/issues/17073

