### PR TITLE
Prevent StepHandler from redirecting to EmailAuthenticator when user is authenticated

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -146,9 +146,9 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
                 (StringUtils.isNotBlank(request.getParameter(EmailOTPAuthenticatorConstants.USER_NAME)) &&
                         getName().equalsIgnoreCase(context.getCurrentAuthenticator()));
         if (canHandleRequest) {
-            log.debug("EmailOTPAuthenticator can handle the request from multi-option step");
+            log.debug("EmailOTPAuthenticator can handle the request from multi-option step.");
         } else {
-            log.debug("EmailOTPAuthenticator cannot handle the request from multi-option step");
+            log.debug("EmailOTPAuthenticator cannot handle the request from multi-option step.");
         }
         return canHandleRequest;
     }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -129,8 +129,18 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
         return ((StringUtils.isNotEmpty(request.getParameter(EmailOTPAuthenticatorConstants.RESEND))
                 && StringUtils.isEmpty(request.getParameter(EmailOTPAuthenticatorConstants.CODE)))
                 || StringUtils.isNotEmpty(request.getParameter(EmailOTPAuthenticatorConstants.CODE))
-                || StringUtils.isNotEmpty(request.getParameter(EmailOTPAuthenticatorConstants.EMAIL_ADDRESS))
-                || StringUtils.isNotEmpty(request.getParameter(EmailOTPAuthenticatorConstants.USER_NAME)));
+                || StringUtils.isNotEmpty(request.getParameter(EmailOTPAuthenticatorConstants.EMAIL_ADDRESS)));
+    }
+
+    @Override
+    public boolean canHandleMultiOptionRequest(HttpServletRequest request, AuthenticationContext context) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Inside EmailOTPAuthenticator canHandleMultiOptionRequest method");
+        }
+        return canHandle(request) ||
+                (StringUtils.isNotBlank(request.getParameter(EmailOTPAuthenticatorConstants.USER_NAME)) &&
+                        getName().equalsIgnoreCase(context.getCurrentAuthenticator()));
     }
 
     @Override

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -126,21 +126,30 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
         if (log.isDebugEnabled()) {
             log.debug("Inside EmailOTPAuthenticator canHandle method");
         }
+        // To handle resend code flow.
         return ((StringUtils.isNotEmpty(request.getParameter(EmailOTPAuthenticatorConstants.RESEND))
                 && StringUtils.isEmpty(request.getParameter(EmailOTPAuthenticatorConstants.CODE)))
+                // To handle OTP code validation flow.
                 || StringUtils.isNotEmpty(request.getParameter(EmailOTPAuthenticatorConstants.CODE))
-                || StringUtils.isNotEmpty(request.getParameter(EmailOTPAuthenticatorConstants.EMAIL_ADDRESS)));
+                // To handle entering email address flow.
+                || StringUtils.isNotEmpty(request.getParameter(EmailOTPAuthenticatorConstants.EMAIL_ADDRESS))
+        );
     }
 
     @Override
-    public boolean canHandleMultiOptionRequest(HttpServletRequest request, AuthenticationContext context) {
+    public boolean canHandleRequestFromMultiOptionStep(HttpServletRequest request, AuthenticationContext context) {
 
-        if (log.isDebugEnabled()) {
-            log.debug("Inside EmailOTPAuthenticator canHandleMultiOptionRequest method");
-        }
-        return canHandle(request) ||
+        // Since all EmailOTP as 1FA, basic, and IDF authenticators has the username parameter in the request, we need to
+        // use the currentAuthenticator context to identify if the request is coming from EmailOTP authenticator.
+        boolean canHandleRequest = canHandle(request) ||
                 (StringUtils.isNotBlank(request.getParameter(EmailOTPAuthenticatorConstants.USER_NAME)) &&
                         getName().equalsIgnoreCase(context.getCurrentAuthenticator()));
+        if (canHandleRequest) {
+            log.debug("EmailOTPAuthenticator can handle the request from multi-option step");
+        } else {
+            log.debug("EmailOTPAuthenticator cannot handle the request from multi-option step");
+        }
+        return canHandleRequest;
     }
 
     @Override

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -141,6 +141,7 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
 
         // Since all EmailOTP as 1FA, basic, and IDF authenticators has the username parameter in the request, we need to
         // use the currentAuthenticator context to identify if the request is coming from EmailOTP authenticator.
+        // For basic and IDF authenticators, the currentAuthenticator context will be null.
         boolean canHandleRequest = canHandle(request) ||
                 (StringUtils.isNotBlank(request.getParameter(EmailOTPAuthenticatorConstants.USER_NAME)) &&
                         getName().equalsIgnoreCase(context.getCurrentAuthenticator()));

--- a/pom.xml
+++ b/pom.xml
@@ -483,7 +483,7 @@
     </distributionManagement>
 
     <properties>
-        <carbon.identity.version>5.25.287</carbon.identity.version>
+        <carbon.identity.version>5.25.450</carbon.identity.version>
         <carbon.identity.event.version>5.18.209</carbon.identity.event.version>
         <commons-logging.version>4.4.3</commons-logging.version>
         <carbon.kernel.version>4.7.0</carbon.kernel.version>


### PR DESCRIPTION
## Purpose
Prevent StepHandler from redirecting to EmailOTPAuthenticator when the user has authenticated with a different authenticator in the same authentication step.

i.e.

First step -> Identifier First
Second Step -> Basic, Email OTP

Scenario: User signs in with their basic authentication password but are then redirected to Email OTP since the Step Handler invokes the canHandle method which returns true.

## Related PR
- https://github.com/wso2-extensions/identity-outbound-auth-email-otp/pull/156
- https://github.com/wso2/carbon-identity-framework/pull/5055

Related issues
- https://github.com/wso2/product-is/issues/17072
- https://github.com/wso2/product-is/issues/17161