### PR TITLE
Add configuration to handle backup codes as an identity claim

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
@@ -79,6 +79,8 @@ public class EmailOTPAuthenticatorConstants {
     public static final String ADMIN_EMAIL = "[userId]";
     public static final String OTP_TOKEN = "otpToken";
     public static final String OTP_BACKUP_CODES_CLAIM = "http://wso2.org/claims/otpbackupcodes";
+    public static final String OTP_BACKUP_CODES_IDENTITY_CLAIM = "http://wso2.org/claims/identity/otpbackupcodes";
+    public static final String HANDLE_BACKUP_CODES_AS_IDENTITY_CLAIM = "OTPBackupCodes.UseIdentityClaims";
     public static final String BACKUP_CODES_SEPARATOR = ",";
 
     public static final String AXIS2 = "axis2.xml";


### PR DESCRIPTION
## Purpose
SMS OTP and TOTP backup codes are stored in the http://wso2.org/claims/otpbackupcodes claim. Ideally, it should be an identity claim

## Goals
>Persist backup codes in an identity claim
## Approach
> Add a deployment.toml configuration to enable treating the backup code claim as an identity claim

## Related PRs
* https://github.com/wso2-extensions/identity-outbound-auth-sms-otp/pull/181
* https://github.com/wso2/carbon-identity-framework/pull/5155

## Related Issues
https://github.com/wso2/product-is/issues/17252