### PR TITLE
Change the numeric OTP field type to be consistent with the UI

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -2349,10 +2349,10 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
         Property numericOTP = new Property();
         numericOTP.setName(EmailOTPAuthenticatorConstants.EMAIL_OTP_NUMERIC_OTP);
         numericOTP.setDisplayName("Use only numeric characters for OTP");
-        numericOTP.setDescription("Please clear this checkbox to enable alphanumeric characters.");
+        numericOTP.setDescription("Please enter either 'true' or 'false' to use only numeric characters or " +
+                "alphanumeric characters respectively.");
         numericOTP.setDefaultValue("true");
-        numericOTP.setType("boolean");
-        numericOTP.setDisplayOrder(5);
+        numericOTP.setDisplayOrder(4);
         configProperties.add(numericOTP);
 
         return configProperties;


### PR DESCRIPTION
## Purpose

The numeric OTP field used in email OTP is registered as a boolean field and this is only getting reflected in the management console UI with the check box added to the field. In the CONSOLE UI the current implementation added as a text box field. The field description is not aligned with the field type. To handle this there is a UI side effort need to be added.

management console:
<img width="1171" alt="Screenshot 2023-12-04 at 09 49 16" src="https://github.com/wso2-extensions/identity-outbound-auth-email-otp/assets/47152272/9c349260-8b08-4abb-baa7-8cda4e666b8e">

new console app:
<img width="1037" alt="Screenshot 2023-12-04 at 09 50 43" src="https://github.com/wso2-extensions/identity-outbound-auth-email-otp/assets/47152272/73ab2c50-c3a0-4300-9306-8b5e074cac09">

- As explained issue [1] connector property doesn't get populated properly when a property type is added.
    - Above screenshot of new console app is taken after the type field is removed from the connector property.

As this is a legacy feature decided to change the field to a text field as in SMS OTP. With this change
> - Both email OTP and SMS OTP  type (numeric/alphanumeric) fields are getting consistent in both management console and new CONSOLE app.
> - The issue [1] is getting fixed.

[1] https://github.com/wso2/product-is/issues/18198

Resolves https://github.com/wso2/product-is/issues/18198
