### PR TITLE
Add skip account lock for init auth flow

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -1099,7 +1099,7 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
         Boolean isLocalUser = isLocalUser(context);
         try {
             if (isLocalUser && !skipAccountLockCheckInInitAuthentication(
-                    context, Boolean.parseBoolean(request.getParameter(EmailOTPAuthenticatorConstants.RESEND)))
+                    context, emailOTPParameters, Boolean.parseBoolean(request.getParameter(EmailOTPAuthenticatorConstants.RESEND)))
                     && EmailOTPUtils.isAccountLocked(authenticatedUser)) {
                 String retryParam;
                 if (showAuthFailureReason) {
@@ -3101,10 +3101,13 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
         return (context.getCurrentStep() == 1 || isPreviousIdPAuthenticationFlowHandler(context));
     }
 
-    private static boolean skipAccountLockCheckInInitAuthentication(AuthenticationContext context, boolean isResend) {
+    private static boolean skipAccountLockCheckInInitAuthentication(AuthenticationContext context,
+                                                                    Map<String, String> emailOTPParameters,
+                                                                    boolean isResend) {
 
-        boolean skipAccountLockCheckInInitAuthenticationConfig = Boolean.parseBoolean(IdentityUtil.getProperty(
-                EmailOTPAuthenticatorConstants.SKIP_ACCOUNT_LOCK_CHECK_IN_INIT_AUTHENTICATION));
+        boolean skipAccountLockCheckInInitAuthenticationConfig =
+                Boolean.parseBoolean(emailOTPParameters
+                        .get(EmailOTPAuthenticatorConstants.SKIP_ACCOUNT_LOCK_CHECK_IN_INIT_AUTHENTICATION));
 
         return skipAccountLockCheckInInitAuthenticationConfig && (!context.isRetrying()
                 || (context.isRetrying() && (isResend

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
@@ -190,6 +190,6 @@ public class EmailOTPAuthenticatorConstants {
     public static final String IS_REDIRECT_TO_EMAIL_OTP = "isRedirectToEmailOTP";
     public static final String MULTI_OPTION_URI = "multiOptionURI";
     public static final String SKIP_ACCOUNT_LOCK_CHECK_IN_INIT_AUTHENTICATION =
-            "EmailOTP.SkipAccountLockCheckInInitAuthentication";
+            "skipAccountLockCheckInInitAuthentication";
 
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
@@ -189,5 +189,7 @@ public class EmailOTPAuthenticatorConstants {
     public static final String EMAIL_OTP_UPPER_CASE_ALPHABET_CHAR_SET = "KIGXHOYSPRWCEFMVUQLZDNABJT";
     public static final String IS_REDIRECT_TO_EMAIL_OTP = "isRedirectToEmailOTP";
     public static final String MULTI_OPTION_URI = "multiOptionURI";
+    public static final String SKIP_ACCOUNT_LOCK_CHECK_IN_INIT_AUTHENTICATION =
+            "EmailOTP.SkipAccountLockCheckInInitAuthentication";
 
 }


### PR DESCRIPTION
## Purpose
In email OTP flow, we're allowing to discover username existence even when the account is locked. This is because, in email OTP we're checking for the account locking in the initiateAuthenticationRequest method. 
Considering the behavioural difference between email OTP and SMS OTP, we are fixing email OTP to have the same behavior as with SMS OTP. However since this is a behavior change, we are adding a config preserving the existing email OTP behavior by default.

Following config can be added to deployment.toml file to enable this change.
```
[authentication.authenticator.email_otp.parameters]
skipAccountLockCheckInInitAuthentication = true
```

## Approach
This config will be evaluated during the `initiateAuthenticationRequest` method before checking for the account locking. Based on the config value, the code will behave as follows.
- If the config is not set/ set to false => Validate for account lock
- If the config is set to true,
    - If it is not a retry path => Skip account lock validation.
    - If it is a retry path and OTP resend or expiry scenario => Skip account lock validation.
    - Else => Validate for account lock