### PR TITLE
Skip triggering email address verification during Email OTP flow

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -75,6 +75,8 @@ import org.wso2.carbon.identity.mgt.mail.DefaultEmailSendingModule;
 import org.wso2.carbon.identity.mgt.mail.Notification;
 import org.wso2.carbon.identity.mgt.mail.NotificationBuilder;
 import org.wso2.carbon.identity.mgt.mail.NotificationData;
+import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
+import org.wso2.carbon.identity.recovery.util.Utils;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.api.UserStoreManager;
@@ -465,6 +467,11 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
                 Object verifiedEmailObject = context.getProperty(EmailOTPAuthenticatorConstants.REQUESTED_USER_EMAIL);
                 if (verifiedEmailObject != null) {
                     try {
+                        if (Utils.getThreadLocalToSkipSendingEmailVerificationOnUpdate() != null) {
+                            Utils.unsetThreadLocalToSkipSendingEmailVerificationOnUpdate();
+                        }
+                        Utils.setThreadLocalToSkipSendingEmailVerificationOnUpdate(IdentityRecoveryConstants.
+                                SkipEmailVerificationOnUpdateStates.SKIP_ON_EMAIL_OTP_FLOW.toString());
                         updateEmailAddressForUsername(context, username);
                     } catch (UserStoreClientException e) {
                         context.setProperty(EmailOTPAuthenticatorConstants.EMAIL_UPDATE_FAILURE, "true");
@@ -479,6 +486,8 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
                         }
                         throw new AuthenticationFailedException("Email claim update failed for user " + username,
                                 e.getCause());
+                    } finally {
+                        Utils.unsetThreadLocalToSkipSendingEmailVerificationOnUpdate();
                     }
                 }
             }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -467,9 +467,6 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
                 Object verifiedEmailObject = context.getProperty(EmailOTPAuthenticatorConstants.REQUESTED_USER_EMAIL);
                 if (verifiedEmailObject != null) {
                     try {
-                        if (Utils.getThreadLocalToSkipSendingEmailVerificationOnUpdate() != null) {
-                            Utils.unsetThreadLocalToSkipSendingEmailVerificationOnUpdate();
-                        }
                         Utils.setThreadLocalToSkipSendingEmailVerificationOnUpdate(IdentityRecoveryConstants.
                                 SkipEmailVerificationOnUpdateStates.SKIP_ON_EMAIL_OTP_FLOW.toString());
                         updateEmailAddressForUsername(context, username);

--- a/pom.xml
+++ b/pom.xml
@@ -487,7 +487,7 @@
         <carbon.identity.event.version>5.18.209</carbon.identity.event.version>
         <commons-logging.version>4.4.3</commons-logging.version>
         <carbon.kernel.version>4.7.0</carbon.kernel.version>
-        <identity.governance.version>1.8.40</identity.governance.version>
+        <identity.governance.version>1.8.101</identity.governance.version>
         <oltu.version>1.0.0.wso2v2</oltu.version>
         <org.apache.oltu.oauth2.client.version>1.0.0</org.apache.oltu.oauth2.client.version>
         <oltu.package.import.version.range>[1.0.0, 2.0.0)</oltu.package.import.version.range>


### PR DESCRIPTION
### Purpose
- Skip triggering an email verification, when the email address was updated by user during the Email OTP flow at the first login where the email address is not previously set. At the moment email address was already verified during the email OTP verification. So no need to verify it again.

### Related Issue

- https://github.com/wso2/product-is/issues/18414

### Related PRs
- https://github.com/wso2-extensions/identity-governance/pull/795