### PR TITLE
Get authenticator name through own function.

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -998,12 +998,10 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
             String email = null;
             StepConfig stepConfig = context.getSequenceConfig().getStepMap().get(context.getCurrentStep() - 1);
             String previousStepAuthenticator = stepConfig.getAuthenticatedAutenticator().getName();
-            StepConfig currentStep = context.getSequenceConfig().getStepMap().get(context.getCurrentStep());
-            String currentStepAuthenticator = currentStep.getAuthenticatorList().iterator().next().getName();
             if (sendOtpToFederatedEmail) {
                 federatedEmailAttributeKey = getFederatedEmailAttributeKey(context, previousStepAuthenticator);
                 if (StringUtils.isEmpty(federatedEmailAttributeKey)) {
-                    federatedEmailAttributeKey = getFederatedEmailAttributeKey(context, currentStepAuthenticator);
+                    federatedEmailAttributeKey = getFederatedEmailAttributeKey(context, getName());
                 }
 
                 // Email OTP authentication is mandatory and user doesn't exist in user store,then send the OTP to
@@ -1633,9 +1631,7 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
         try {
             if (sendOtpToFederatedEmail) {
                 if (StringUtils.isEmpty(federatedEmailAttributeKey)) {
-                    federatedEmailAttributeKey = getFederatedEmailAttributeKey(context, context.getSequenceConfig()
-                            .getStepMap().get(context.getCurrentStep()).getAuthenticatorList().iterator().next()
-                            .getName());
+                    federatedEmailAttributeKey = getFederatedEmailAttributeKey(context, getName());
                 }
 
                 String email = getEmailForFederatedUser(userAttributes, federatedEmailAttributeKey);


### PR DESCRIPTION
## Purpose
> In the EmailOTPAuthenticator, the authenticator name is retrieved through the authenticators of the current step. This has caused inconsistencies when both emailOTP and smsOTP are configured in the same step. However inside the EmailOTPAuthenticator class it is not necessary to read the authenticator name through current step since the authenticator is itself. 
This PR fixes this issue by retrieving the name of the authenticator by its own `getName()` function. 

## Relate Issue 
https://github.com/wso2/product-is/issues/19482