### PR TITLE
Fix NPE in EmailOTP Authenticator when context.isRetrying() is true

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -160,6 +160,12 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
                                            HttpServletResponse response,
                                            AuthenticationContext context)
             throws AuthenticationFailedException, LogoutFailedException {
+
+        // If the current authenticator is not EMAIL OTP, then set the flow to not retrying which could have been
+        // set from other authenticators and not cleared.
+        if (!EmailOTPAuthenticatorConstants.AUTHENTICATOR_NAME.equals(context.getCurrentAuthenticator())) {
+            context.setRetrying(false);
+        }
         // if the logout request comes, then no need to go through and complete the flow.
         if (context.isLogoutRequest()) {
             return AuthenticatorFlowStatus.SUCCESS_COMPLETED;
@@ -168,7 +174,7 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
             initiateAuthenticationRequest(request, response, context);
             return AuthenticatorFlowStatus.INCOMPLETE;
         } else if (StringUtils.isEmpty(request.getParameter(EmailOTPAuthenticatorConstants.CODE)) &&
-                StringUtils.isEmpty(request.getParameter(EmailOTPAuthenticatorConstants.RESEND))) {
+                !Boolean.parseBoolean(request.getParameter(EmailOTPAuthenticatorConstants.RESEND))) {
             AuthenticatedUser authenticatedUser = getAuthenticatedUser(context);
             if (authenticatedUser == null) {
                 if (StringUtils.isEmpty(request.getParameter(EmailOTPAuthenticatorConstants.USER_NAME))) {


### PR DESCRIPTION
## Purpose
- context.isRetrying() is set to `true` from previous failed authenticator.
- If the current authenticator set in the context is different than EMAIL OTP, then `context.isRetrying()` can be reset considering this is the first time the authentication flow is entering email OTP authenticator.

### Related Issues
- https://github.com/wso2/product-is/issues/20282