### PR TITLE
Add account lock capability to Email OTP Service

### DIFF
--- a/component/common/pom.xml
+++ b/component/common/pom.xml
@@ -108,6 +108,12 @@
                             org.wso2.carbon.context; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.store;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.application.authentication.framework.exception;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.application.common.model;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.core.util;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.event; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.event.event;
                             version="${carbon.identity.package.import.version.range}",
@@ -115,6 +121,7 @@
                             version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.event.services;
                             version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.governance;version="${identity.governance.imp.pkg.version.range}",
                             org.wso2.carbon.identity.governance.service.notification;
                             version="${identity.governance.imp.pkg.version.range}",
                             org.wso2.carbon.identity.recovery.internal;
@@ -124,7 +131,11 @@
                             org.wso2.carbon.user.core.common; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.constants;
                             version="${carbon.kernel.package.import.version.range}",
-                            org.wso2.carbon.user.core.service; version="${carbon.kernel.package.import.version.range}"
+                            org.wso2.carbon.user.core.service; version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.identity.handler.event.account.lock.exception;
+                            version="${carbon.identity.account.lock.handler.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.handler.event.account.lock.service;
+                            version="${carbon.identity.account.lock.handler.imp.pkg.version.range}"
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.extension.identity.emailotp.common.internal,

--- a/component/common/pom.xml
+++ b/component/common/pom.xml
@@ -108,8 +108,6 @@
                             org.wso2.carbon.context; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.store;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
-                            org.wso2.carbon.identity.application.authentication.framework.exception;
-                            version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.common.model;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.core.util;

--- a/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/EmailOtpServiceImpl.java
+++ b/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/EmailOtpServiceImpl.java
@@ -570,6 +570,8 @@ public class EmailOtpServiceImpl implements EmailOtpService {
     /**
      * Reset OTP Failed Attempts count upon successful completion of the OTP verification.
      *
+     * @param userId The ID of the user.
+     * @throws EmailOtpException If an error occurred.
      */
     private void resetOtpFailedAttempts(String userId) throws EmailOtpException {
 

--- a/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/EmailOtpServiceImpl.java
+++ b/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/EmailOtpServiceImpl.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.extension.identity.emailotp.common;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -35,6 +36,8 @@ import org.wso2.carbon.extension.identity.emailotp.common.internal.EmailOtpServi
 import org.wso2.carbon.extension.identity.emailotp.common.util.OneTimePasswordUtils;
 import org.wso2.carbon.extension.identity.emailotp.common.util.Utils;
 import org.wso2.carbon.identity.application.authentication.framework.store.SessionDataStore;
+import org.wso2.carbon.identity.application.common.model.Property;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
@@ -201,12 +204,15 @@ public class EmailOtpServiceImpl implements EmailOtpService {
                 throw Utils.handleServerException(Constants.ErrorMessage.SERVER_JSON_SESSION_MAPPER_ERROR, null, e);
             }
 
-            ValidationResponseDTO responseDTO = isValid(sessionDTO, emailOTP, userId, transactionId, showFailureReason, sessionId);
+            ValidationResponseDTO responseDTO = isValid(sessionDTO, emailOTP, userId, transactionId, showFailureReason,
+                    true);
             if (!responseDTO.isValid()) {
                 return responseDTO;
             }
             // Valid OTP. Clear OTP session data.
                 SessionDataStore.getInstance().clearSessionData(Utils.getHash(userId), Constants.SESSION_TYPE_OTP);
+
+            resetOtpFailedAttempts(userId);
 
             return new ValidationResponseDTO(userId, true);
         } else {
@@ -229,13 +235,16 @@ public class EmailOtpServiceImpl implements EmailOtpService {
                 throw Utils.handleServerException(Constants.ErrorMessage.SERVER_JSON_SESSION_MAPPER_ERROR, null, e);
             }
 
-            ValidationResponseDTO responseDTO = isValid(sessionDTO, emailOTP, userId, transactionId, showFailureReason, sessionId);
+            ValidationResponseDTO responseDTO = isValid(sessionDTO, emailOTP, userId, transactionId, showFailureReason,
+                    true);
             if (!responseDTO.isValid()) {
                 return responseDTO;
             }
 
             // Valid OTP. Clear OTP session data.
             SessionDataStore.getInstance().clearSessionData(Utils.getHash(userId, transactionId), Constants.SESSION_TYPE_OTP);
+
+            resetOtpFailedAttempts(userId);
 
             return new ValidationResponseDTO(userId, true);
         }
@@ -277,7 +286,8 @@ public class EmailOtpServiceImpl implements EmailOtpService {
                 throw Utils.handleServerException(Constants.ErrorMessage.SERVER_JSON_SESSION_MAPPER_ERROR, null, e);
             }
 
-            ValidationResponseDTO responseDTO = isValid(sessionDTO, emailOTP, userId, transactionId, showFailureReason, sessionId);
+            ValidationResponseDTO responseDTO = isValid(sessionDTO, emailOTP, userId, transactionId, showFailureReason,
+                    false);
             if (!responseDTO.isValid()) {
                 return responseDTO;
             }
@@ -303,7 +313,8 @@ public class EmailOtpServiceImpl implements EmailOtpService {
                 throw Utils.handleServerException(Constants.ErrorMessage.SERVER_JSON_SESSION_MAPPER_ERROR, null, e);
             }
 
-            ValidationResponseDTO responseDTO = isValid(sessionDTO, emailOTP, userId, transactionId, showFailureReason, sessionId);
+            ValidationResponseDTO responseDTO = isValid(sessionDTO, emailOTP, userId, transactionId, showFailureReason,
+                    false);
             if (!responseDTO.isValid()) {
                 return responseDTO;
             }
@@ -312,14 +323,18 @@ public class EmailOtpServiceImpl implements EmailOtpService {
         }
     }
 
-    private ValidationResponseDTO isValid(SessionDTO sessionDTO, String emailOtp, String userId,
-                                          String transactionId, boolean showFailureReason, String sessionId) throws EmailOtpServerException {
+    private ValidationResponseDTO isValid(SessionDTO sessionDTO, String emailOtp, String userId, String transactionId,
+                                          boolean showFailureReason, boolean validateEmailOTP)
+            throws EmailOtpException {
 
         FailureReasonDTO error;
         // Check if the provided OTP is correct.
         if (!StringUtils.equals(emailOtp, sessionDTO.getOtpToken())) {
             if (log.isDebugEnabled()) {
                 log.debug(String.format("Invalid OTP provided for the user : %s.", userId));
+            }
+            if (validateEmailOTP) {
+                handleOtpVerificationFailure(userId);
             }
             error = showFailureReason
                     ? new FailureReasonDTO(Constants.ErrorMessage.CLIENT_OTP_VALIDATION_FAILED, userId)
@@ -547,5 +562,179 @@ public class EmailOtpServiceImpl implements EmailOtpService {
     private int getTenantId() {
 
         return PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
+    }
+
+    /**
+     * Reset OTP Failed Attempts count upon successful completion of the OTP verification.
+     *
+     */
+    private void resetOtpFailedAttempts(String userId) throws EmailOtpException {
+
+        if (!EmailOtpServiceDataHolder.getConfigs().isLockAccountOnFailedAttempts()) {
+            return;
+        }
+        User user = getUserById(userId);
+
+        Property[] connectorConfigs = Utils.getAccountLockConnectorConfigs(user.getTenantDomain());
+        // Return if account lock handler is not enabled.
+        for (Property connectorConfig : connectorConfigs) {
+            if ((Constants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE.equals(connectorConfig.getName())) &&
+                    !Boolean.parseBoolean(connectorConfig.getValue())) {
+                return;
+            }
+        }
+
+        try {
+            AbstractUserStoreManager userStoreManager = (AbstractUserStoreManager) EmailOtpServiceDataHolder
+                    .getInstance().getRealmService().getTenantUserRealm(getTenantId()).getUserStoreManager();
+
+            String[] claimsToCheck = {Constants.EMAIL_OTP_FAILED_ATTEMPTS_CLAIM, Constants.ACCOUNT_LOCKED_CLAIM};
+            Map<String, String> userClaims = userStoreManager.getUserClaimValues(user.getDomainQualifiedUsername(),
+                    claimsToCheck, UserCoreConstants.DEFAULT_PROFILE);
+            String failedEmailOtpAttemptsClaimValue = userClaims.get(Constants.EMAIL_OTP_FAILED_ATTEMPTS_CLAIM);
+            String accountLockClaimValue = userClaims.get(Constants.ACCOUNT_LOCKED_CLAIM);
+
+            Map<String, String> updatedClaims = new HashMap<>();
+            if (NumberUtils.isNumber(failedEmailOtpAttemptsClaimValue) &&
+                    Integer.parseInt(failedEmailOtpAttemptsClaimValue) > 0) {
+                updatedClaims.put(Constants.EMAIL_OTP_FAILED_ATTEMPTS_CLAIM, "0");
+            }
+            if (Boolean.parseBoolean(accountLockClaimValue)) {
+                updatedClaims.put(Constants.ACCOUNT_LOCKED_CLAIM, Boolean.FALSE.toString());
+                updatedClaims.put(Constants.ACCOUNT_UNLOCK_TIME_CLAIM, "0");
+            }
+            if (!updatedClaims.isEmpty()) {
+                userStoreManager.setUserClaimValues(user.getDomainQualifiedUsername(), updatedClaims,
+                        UserCoreConstants.DEFAULT_PROFILE);
+            }
+        } catch (UserStoreException e) {
+            String errorMessage = String.format("Failed to reset failed attempts count for user ID : %s.",
+                    user.getUserID());
+            log.error(errorMessage, e);
+            throw Utils.handleServerException(Constants.ErrorMessage.SERVER_USER_STORE_MANAGER_ERROR,
+                    errorMessage, e);
+        }
+    }
+
+    private void handleOtpVerificationFailure(String userId) throws EmailOtpException {
+
+        User user = getUserById(userId);
+        boolean lockAccountOnFailedAttempts = EmailOtpServiceDataHolder.getConfigs().isLockAccountOnFailedAttempts();
+        if (!lockAccountOnFailedAttempts || Utils.isAccountLocked(user)) {
+            return;
+        }
+
+        int maxAttempts = 0;
+        long unlockTimePropertyValue = 0;
+        double unlockTimeRatio = 1;
+
+        Property[] connectorConfigs = Utils.getAccountLockConnectorConfigs(user.getTenantDomain());
+        for (Property connectorConfig : connectorConfigs) {
+            switch (connectorConfig.getName()) {
+                case Constants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE:
+                    if (!Boolean.parseBoolean(connectorConfig.getValue())) {
+                        return;
+                    }
+                case Constants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE_MAX:
+                    if (NumberUtils.isNumber(connectorConfig.getValue())) {
+                        maxAttempts = Integer.parseInt(connectorConfig.getValue());
+                    }
+                    break;
+                case Constants.PROPERTY_ACCOUNT_LOCK_TIME:
+                    if (NumberUtils.isNumber(connectorConfig.getValue())) {
+                        unlockTimePropertyValue = Integer.parseInt(connectorConfig.getValue());
+                    }
+                    break;
+                case Constants.PROPERTY_LOGIN_FAIL_TIMEOUT_RATIO:
+                    if (NumberUtils.isNumber(connectorConfig.getValue())) {
+                        double value = Double.parseDouble(connectorConfig.getValue());
+                        if (value > 0) {
+                            unlockTimeRatio = value;
+                        }
+                    }
+                    break;
+            }
+        }
+
+        Map<String, String> claimValues = getUserClaimValues(user, new String[]{
+                Constants.EMAIL_OTP_FAILED_ATTEMPTS_CLAIM, Constants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM});
+        if (claimValues == null) {
+            claimValues = new HashMap<>();
+        }
+        int currentAttempts = 0;
+        if (NumberUtils.isNumber(claimValues.get(Constants.EMAIL_OTP_FAILED_ATTEMPTS_CLAIM))) {
+            currentAttempts = Integer.parseInt(claimValues.get(Constants.EMAIL_OTP_FAILED_ATTEMPTS_CLAIM));
+        }
+        int failedLoginLockoutCountValue = 0;
+        if (NumberUtils.isNumber(claimValues.get(Constants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM))) {
+            failedLoginLockoutCountValue = Integer.parseInt(claimValues.get(Constants
+                    .FAILED_LOGIN_LOCKOUT_COUNT_CLAIM));
+        }
+
+        Map<String, String> updatedClaims = new HashMap<>();
+        if ((currentAttempts + 1) >= maxAttempts) {
+            // Calculate the incremental unlock time interval in milli seconds.
+            unlockTimePropertyValue = (long) (unlockTimePropertyValue * 1000 * 60 * Math.pow(unlockTimeRatio,
+                    failedLoginLockoutCountValue));
+            // Calculate unlock-time by adding current-time and unlock-time-interval in milliseconds.
+            long unlockTime = System.currentTimeMillis() + unlockTimePropertyValue;
+            updatedClaims.put(Constants.ACCOUNT_LOCKED_CLAIM, Boolean.TRUE.toString());
+            updatedClaims.put(Constants.EMAIL_OTP_FAILED_ATTEMPTS_CLAIM, "0");
+            updatedClaims.put(Constants.ACCOUNT_UNLOCK_TIME_CLAIM, String.valueOf(unlockTime));
+            updatedClaims.put(Constants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM,
+                    String.valueOf(failedLoginLockoutCountValue + 1));
+            updatedClaims.put(Constants.ACCOUNT_LOCKED_REASON_CLAIM_URI, Constants.MAX_EMAIL_OTP_ATTEMPTS_EXCEEDED);
+            IdentityUtil.threadLocalProperties.get().put(Constants.ADMIN_INITIATED, false);
+            setUserClaimValues(user, updatedClaims);
+            throw Utils.handleClientException(Constants.ErrorMessage.CLIENT_ACCOUNT_LOCKED, user.getUserID());
+        } else {
+            updatedClaims.put(Constants.EMAIL_OTP_FAILED_ATTEMPTS_CLAIM, String.valueOf(currentAttempts + 1));
+            setUserClaimValues(user, updatedClaims);
+        }
+    }
+
+    private Map<String, String> getUserClaimValues(User user, String[] claims) throws EmailOtpServerException {
+
+        try {
+            AbstractUserStoreManager userStoreManager = (AbstractUserStoreManager) EmailOtpServiceDataHolder
+                    .getInstance().getRealmService().getTenantUserRealm(getTenantId()).getUserStoreManager();
+            return userStoreManager.getUserClaimValues(user.getDomainQualifiedUsername(), claims,
+                    UserCoreConstants.DEFAULT_PROFILE);
+        } catch (UserStoreException e) {
+            log.error("Error while reading user claims.", e);
+            throw Utils.handleServerException(Constants.ErrorMessage.SERVER_USER_STORE_MANAGER_ERROR,
+                    String.format("Failed to read user claims for user ID : %s.", user.getUserID()), e);
+        }
+    }
+
+    private void setUserClaimValues(User user, Map<String, String> updatedClaims) throws EmailOtpServerException {
+
+        try {
+            AbstractUserStoreManager userStoreManager = (AbstractUserStoreManager) EmailOtpServiceDataHolder
+                    .getInstance().getRealmService().getTenantUserRealm(getTenantId()).getUserStoreManager();
+            userStoreManager.setUserClaimValues(user.getDomainQualifiedUsername(), updatedClaims,
+                    UserCoreConstants.DEFAULT_PROFILE);
+        } catch (UserStoreException e) {
+            log.error("Error while updating user claims", e);
+            throw Utils.handleServerException(Constants.ErrorMessage.SERVER_USER_STORE_MANAGER_ERROR,
+                    String.format("Failed to update user claims for user ID: %s.", user.getUserID()), e);
+        }
+    }
+
+    private User getUserById(String userId) throws EmailOtpException {
+
+        try {
+            AbstractUserStoreManager userStoreManager = (AbstractUserStoreManager) EmailOtpServiceDataHolder
+                    .getInstance().getRealmService().getTenantUserRealm(getTenantId()).getUserStoreManager();
+            return userStoreManager.getUser(userId, null);
+        } catch (UserStoreException e) {
+            // Handle user not found.
+            String errorCode = ((org.wso2.carbon.user.core.UserStoreException) e).getErrorCode();
+            if (UserCoreErrorConstants.ErrorMessages.ERROR_CODE_NON_EXISTING_USER.getCode().equals(errorCode)) {
+                throw Utils.handleClientException(Constants.ErrorMessage.CLIENT_INVALID_USER_ID, userId);
+            }
+            throw Utils.handleServerException(Constants.ErrorMessage.SERVER_USER_STORE_MANAGER_ERROR,
+                    String.format("Error while retrieving user for the ID : %s.", userId), e);
+        }
     }
 }

--- a/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/constant/Constants.java
+++ b/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/constant/Constants.java
@@ -50,6 +50,21 @@ public class Constants {
     public static final String EMAIL_OTP_RESEND_THROTTLE_INTERVAL = "emailOtp.resendThrottleInterval";
     public static final String EMAIL_OTP_SHOW_FAILURE_REASON = "emailOtp.showValidationFailureReason";
     public static final String EMAIL_OTP_MULTIPLE_SESSIONS_ENABLED = "emailOtp.isEnableMultipleSessions";
+    public static final String EMAIL_OTP_LOCK_ACCOUNT_ON_FAILED_ATTEMPTS = "emailOtp.lockAccountOnFailedAttempts";
+
+    public static final String PROPERTY_LOGIN_FAIL_TIMEOUT_RATIO = "account.lock.handler.login.fail.timeout.ratio";
+    public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE = "account.lock.handler.enable";
+    public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE_MAX = "account.lock.handler.On.Failure.Max.Attempts";
+    public static final String PROPERTY_ACCOUNT_LOCK_TIME = "account.lock.handler.Time";
+    public static final String EMAIL_OTP_FAILED_ATTEMPTS_CLAIM =
+            "http://wso2.org/claims/identity/failedEmailOtpAttempts";
+    public static final String FAILED_LOGIN_LOCKOUT_COUNT_CLAIM =
+            "http://wso2.org/claims/identity/failedLoginLockoutCount";
+    public static final String ACCOUNT_LOCKED_CLAIM = "http://wso2.org/claims/identity/accountLocked";
+    public static final String ACCOUNT_UNLOCK_TIME_CLAIM = "http://wso2.org/claims/identity/unlockTime";
+    public static final String ACCOUNT_LOCKED_REASON_CLAIM_URI = "http://wso2.org/claims/identity/lockedReason";
+    public static final String MAX_EMAIL_OTP_ATTEMPTS_EXCEEDED = "MAX_EMAIL_OTP_ATTEMPTS_EXCEEDED";
+    public static final String ADMIN_INITIATED = "AdminInitiated";
 
     /**
      * EMAIL OTP service error codes.
@@ -72,11 +87,13 @@ public class Constants {
         CLIENT_OTP_USER_VALIDATION_FAILED("EMAIL-60008", "OTP user validation failed.",
                 "Provided OTP doesn't belong to the mentioned user : %s."),
         CLIENT_OTP_VALIDATION_FAILED("EMAIL-60009", "Provided OTP is invalid.",
-                "Provided OTP is invalid."),
+                "Provided OTP is invalid for the user ID: %s."),
         CLIENT_SLOW_DOWN_RESEND("EMAIL-60010", "Slow down.",
                 "Please wait %s seconds before retrying."),
-        CLIENT_NO_OTP_FOR_USER("EMAIL-60011", "No OTP fround for the user.",
+        CLIENT_NO_OTP_FOR_USER("EMAIL-60011", "No OTP found for the user.",
                 "No OTP found for the user Id : %s."),
+        CLIENT_ACCOUNT_LOCKED("EMAIL-60012", "Account locked.",
+                "Account is locked for the user ID: %s."),
 
         // Server error codes.
         SERVER_USER_STORE_MANAGER_ERROR("EMAIL-65001", "User store manager error.",
@@ -100,7 +117,11 @@ public class Constants {
         SERVER_INVALID_RENEWAL_INTERVAL_ERROR("EMAIL-65010", "Invalid renewal interval value.",
                 "Renewal interval should be smaller than the OTP validity period. Renewal interval: %s."),
         SERVER_UNEXPECTED_ERROR("EMAIL-65011", "An unexpected server error occurred.",
-                "An unexpected server error occurred.");
+                "An unexpected server error occurred."),
+        SERVER_ERROR_VALIDATING_ACCOUNT_LOCK_STATUS("EMAIL-65012", "Error validating account lock status.",
+                "Server encountered an error while validating account lock status for the user ID : %s."),
+        SERVER_ERROR_RETRIEVING_ACCOUNT_LOCK_CONFIGS("EMAIL-65013", "Can't retrieve account lock connector " +
+                "configurations.", "Server encountered an error while retrieving account lock connector configurations.");
 
         private final String code;
         private final String message;

--- a/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/constant/Constants.java
+++ b/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/constant/Constants.java
@@ -52,10 +52,6 @@ public class Constants {
     public static final String EMAIL_OTP_MULTIPLE_SESSIONS_ENABLED = "emailOtp.isEnableMultipleSessions";
     public static final String EMAIL_OTP_LOCK_ACCOUNT_ON_FAILED_ATTEMPTS = "emailOtp.lockAccountOnFailedAttempts";
 
-    public static final String PROPERTY_LOGIN_FAIL_TIMEOUT_RATIO = "account.lock.handler.login.fail.timeout.ratio";
-    public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE = "account.lock.handler.enable";
-    public static final String PROPERTY_ACCOUNT_LOCK_ON_FAILURE_MAX = "account.lock.handler.On.Failure.Max.Attempts";
-    public static final String PROPERTY_ACCOUNT_LOCK_TIME = "account.lock.handler.Time";
     public static final String EMAIL_OTP_FAILED_ATTEMPTS_CLAIM =
             "http://wso2.org/claims/identity/failedEmailOtpAttempts";
     public static final String FAILED_LOGIN_LOCKOUT_COUNT_CLAIM =

--- a/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/dto/ConfigsDTO.java
+++ b/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/dto/ConfigsDTO.java
@@ -34,6 +34,7 @@ public class ConfigsDTO {
     private int otpRenewalInterval;
     private int resendThrottleInterval;
     private boolean isEnableMultipleSessions;
+    private boolean lockAccountOnFailedAttempts;
 
     public boolean isEnabled() {
 
@@ -145,6 +146,16 @@ public class ConfigsDTO {
         isEnableMultipleSessions = enableMultipleSessions;
     }
 
+    public boolean isLockAccountOnFailedAttempts() {
+
+        return lockAccountOnFailedAttempts;
+    }
+
+    public void setLockAccountOnFailedAttempts(boolean lockAccountOnFailedAttempts) {
+
+        this.lockAccountOnFailedAttempts = lockAccountOnFailedAttempts;
+    }
+
     @Override
     public String toString() {
 
@@ -160,6 +171,7 @@ public class ConfigsDTO {
                 .append(",\n\totpRenewalInterval = ").append(otpRenewalInterval)
                 .append(",\n\tresendThrottleInterval = ").append(resendThrottleInterval)
                 .append(",\n\tisEnableMultipleSessions = ").append(isEnableMultipleSessions)
+                .append(",\n\tlockAccountOnFailedAttempts = ").append(lockAccountOnFailedAttempts)
                 .append("\n}");
         return sb.toString();
     }

--- a/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/internal/EmailOtpServiceComponent.java
+++ b/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/internal/EmailOtpServiceComponent.java
@@ -105,12 +105,12 @@ public class EmailOtpServiceComponent {
             policy = ReferencePolicy.DYNAMIC,
             unbind = "unsetIdentityGovernanceService"
     )
-    protected void setIdentityGovernanceService(IdentityGovernanceService idpManager) {
+    protected void setIdentityGovernanceService(IdentityGovernanceService identityGovernanceService) {
 
-        EmailOtpServiceDataHolder.getInstance().setIdentityGovernanceService(idpManager);
+        EmailOtpServiceDataHolder.getInstance().setIdentityGovernanceService(identityGovernanceService);
     }
 
-    protected void unsetIdentityGovernanceService(IdentityGovernanceService idpManager) {
+    protected void unsetIdentityGovernanceService(IdentityGovernanceService identityGovernanceService) {
 
         EmailOtpServiceDataHolder.getInstance().setIdentityGovernanceService(null);
     }

--- a/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/internal/EmailOtpServiceComponent.java
+++ b/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/internal/EmailOtpServiceComponent.java
@@ -30,6 +30,8 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.extension.identity.emailotp.common.EmailOtpService;
 import org.wso2.carbon.extension.identity.emailotp.common.EmailOtpServiceImpl;
 import org.wso2.carbon.extension.identity.emailotp.common.util.Utils;
+import org.wso2.carbon.identity.governance.IdentityGovernanceService;
+import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
 import org.wso2.carbon.user.core.service.RealmService;
 
 /**
@@ -77,5 +79,39 @@ public class EmailOtpServiceComponent {
             log.debug("Unset the Realm Service.");
         }
         EmailOtpServiceDataHolder.getInstance().setRealmService(null);
+    }
+
+    @Reference(
+            name = "AccountLockService",
+            service = org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetAccountLockService"
+    )
+    protected void setAccountLockService(AccountLockService accountLockService) {
+
+        EmailOtpServiceDataHolder.getInstance().setAccountLockService(accountLockService);
+    }
+
+    protected void unsetAccountLockService(AccountLockService accountLockService) {
+
+        EmailOtpServiceDataHolder.getInstance().setAccountLockService(null);
+    }
+
+    @Reference(
+            name = "IdentityGovernanceService",
+            service = org.wso2.carbon.identity.governance.IdentityGovernanceService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetIdentityGovernanceService"
+    )
+    protected void setIdentityGovernanceService(IdentityGovernanceService idpManager) {
+
+        EmailOtpServiceDataHolder.getInstance().setIdentityGovernanceService(idpManager);
+    }
+
+    protected void unsetIdentityGovernanceService(IdentityGovernanceService idpManager) {
+
+        EmailOtpServiceDataHolder.getInstance().setIdentityGovernanceService(null);
     }
 }

--- a/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/internal/EmailOtpServiceDataHolder.java
+++ b/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/internal/EmailOtpServiceDataHolder.java
@@ -19,6 +19,8 @@
 package org.wso2.carbon.extension.identity.emailotp.common.internal;
 
 import org.wso2.carbon.extension.identity.emailotp.common.dto.ConfigsDTO;
+import org.wso2.carbon.identity.governance.IdentityGovernanceService;
+import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
 import org.wso2.carbon.user.core.service.RealmService;
 
 /**
@@ -28,6 +30,8 @@ public class EmailOtpServiceDataHolder {
 
     private static final EmailOtpServiceDataHolder dataHolder = new EmailOtpServiceDataHolder();
     private RealmService realmService;
+    private AccountLockService accountLockService;
+    private IdentityGovernanceService identityGovernanceService;
     private static final ConfigsDTO configs = new ConfigsDTO();
 
     /**
@@ -68,5 +72,45 @@ public class EmailOtpServiceDataHolder {
     public static ConfigsDTO getConfigs() {
 
         return configs;
+    }
+
+    /**
+     * Get Account Lock service.
+     *
+     * @return Account Lock service.
+     */
+    public AccountLockService getAccountLockService() {
+
+        return accountLockService;
+    }
+
+    /**
+     * Set Account Lock service.
+     *
+     * @param accountLockService Account Lock service.
+     */
+    public void setAccountLockService(AccountLockService accountLockService) {
+
+        this.accountLockService = accountLockService;
+    }
+
+    /**
+     * Get Identity Governance service.
+     *
+     * @return Identity Governance service.
+     */
+    public IdentityGovernanceService getIdentityGovernanceService() {
+
+        return identityGovernanceService;
+    }
+
+    /**
+     * Set Identity Governance service.
+     *
+     * @param identityGovernanceService Identity Governance service.
+     */
+    public void setIdentityGovernanceService(IdentityGovernanceService identityGovernanceService) {
+
+        this.identityGovernanceService = identityGovernanceService;
     }
 }

--- a/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/util/Utils.java
+++ b/component/common/src/main/java/org/wso2/carbon/extension/identity/emailotp/common/util/Utils.java
@@ -38,6 +38,11 @@ import org.wso2.carbon.user.core.common.User;
 import java.util.Properties;
 import java.util.UUID;
 
+import static org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants.ACCOUNT_LOCKED_PROPERTY;
+import static org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants.ACCOUNT_UNLOCK_TIME_PROPERTY;
+import static org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants.FAILED_LOGIN_ATTEMPTS_PROPERTY;
+import static org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants.LOGIN_FAIL_TIMEOUT_RATIO_PROPERTY;
+
 /**
  * Util functions for Email OTP service.
  */
@@ -263,6 +268,9 @@ public class Utils {
     public static boolean isAccountLocked(User user) throws EmailOtpServerException {
 
         try {
+            if (user == null) {
+                return false;
+            }
             return EmailOtpServiceDataHolder.getInstance().getAccountLockService().isAccountLocked(user.getUsername(),
                     user.getTenantDomain(), user.getUserStoreDomain());
         } catch (AccountLockServiceException e) {
@@ -282,9 +290,8 @@ public class Utils {
 
         try {
             return EmailOtpServiceDataHolder.getInstance().getIdentityGovernanceService().getConfiguration
-                    (new String[]{Constants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE,
-                            Constants.PROPERTY_ACCOUNT_LOCK_ON_FAILURE_MAX, Constants.PROPERTY_ACCOUNT_LOCK_TIME,
-                            Constants.PROPERTY_LOGIN_FAIL_TIMEOUT_RATIO}, tenantDomain);
+                    (new String[]{ACCOUNT_LOCKED_PROPERTY, FAILED_LOGIN_ATTEMPTS_PROPERTY, ACCOUNT_UNLOCK_TIME_PROPERTY,
+                            LOGIN_FAIL_TIMEOUT_RATIO_PROPERTY}, tenantDomain);
         } catch (IdentityGovernanceException e) {
             throw Utils.handleServerException(Constants.ErrorMessage.SERVER_ERROR_RETRIEVING_ACCOUNT_LOCK_CONFIGS, null,
                     e);

--- a/docs/email_otp_service.md
+++ b/docs/email_otp_service.md
@@ -25,7 +25,14 @@ properties.tokenRenewalInterval= 60
 # Throttle OTP generation requests from the same user Id.
 # Set '0' for no throttling.
 properties.resendThrottleInterval = 30
+# Lock the account after reaching the maximum number of failed login attempts.
+properties.lockAccountOnFailedAttempts = true
 ```
+
+   **NOTE:** If `properties.lockAccountOnFailedAttempts` is set to `true`, at tenant level it is required to enable
+   the account lock capability and configure other properties such as unlock time duration.
+   For more details, refer to the documentation: https://is.docs.wso2.com/en/5.11.0/learn/account-locking-by-failed-login-attempts/#configuring-wso2-is-for-account-locking
+
 4. If notifications are managed by the Identity Server, configure the **Email template** by appending below at the end of
    the `<IS_HOME>/repository/conf/email/email-templates-admin-config.xml` file.
 ```xml


### PR DESCRIPTION
Locking the account on failed attempts is made configurable via deployment.toml file as shown in the example below.

```
[[event_handler]]
name= "emailOtp"
properties.enabled=true
properties.lockAccountOnFailedAttempts = true
```

In addition to this, at tenant level it is required to enable the account lock capability and configure other properties such as unlock time duration etc (https://is.docs.wso2.com/en/5.11.0/learn/account-locking-by-failed-login-attempts/#configuring-wso2-is-for-account-locking).