### PR TITLE
Add custom template to the Email OTP from runtime params through adaptive script

### DIFF
--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
@@ -155,6 +155,7 @@ public class EmailOTPAuthenticatorConstants {
     public static final String STATUS_OTP_EXPIRED = "otp-expired";
     public static final String STATUS_CODE_MISMATCH = "code-mismatch";
     public static final String TRUE = "true";
+    public static final String EMAIL_TEMPLATE_TYPE = "notificationTemplate";
 
     // Account lock related constants.
     public static final String EMAIL_OTP_FAILED_ATTEMPTS_CLAIM =

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorTest.java
@@ -392,7 +392,7 @@ public class EmailOTPAuthenticatorTest {
         // source is compatible with java 11.
         when(OneTimePassword.getRandomNumber(EmailOTPAuthenticatorConstants.SECRET_KEY_LENGTH)).thenReturn("123456");
         doNothing().when(emailOTPAuthenticator, "sendOTP", anyString(), anyString(), anyString(), anyObject(),
-                anyString());
+                anyString(), anyString());
         AuthenticatorFlowStatus status = emailOTPAuthenticator.process(httpServletRequest, httpServletResponse,
                 context);
         Assert.assertEquals(status, AuthenticatorFlowStatus.INCOMPLETE);
@@ -427,7 +427,7 @@ public class EmailOTPAuthenticatorTest {
         // source is compatible with java 11.
         when(OneTimePassword.getRandomNumber(EmailOTPAuthenticatorConstants.SECRET_KEY_LENGTH)).thenReturn("123456");
         doNothing().when(emailOTPAuthenticator, "sendOTP", anyString(), anyString(), anyString(), anyObject(),
-                anyString());
+                anyString(), anyString());
         AuthenticatorFlowStatus status = emailOTPAuthenticator.process(httpServletRequest, httpServletResponse,
                 context);
         Assert.assertEquals(status, AuthenticatorFlowStatus.INCOMPLETE);
@@ -470,7 +470,7 @@ public class EmailOTPAuthenticatorTest {
         // source is compatible with java 11.
         when(OneTimePassword.getRandomNumber(EmailOTPAuthenticatorConstants.SECRET_KEY_LENGTH)).thenReturn("123456");
         doNothing().when(spiedEmailOTPAuthenticator, "sendOTP", anyString(), anyString(), anyString(), anyObject(),
-                anyString());
+                anyString(), anyString());
         AuthenticatorFlowStatus status = spiedEmailOTPAuthenticator.process(httpServletRequest, httpServletResponse,
                 context);
         Assert.assertEquals(status, AuthenticatorFlowStatus.INCOMPLETE);
@@ -514,7 +514,7 @@ public class EmailOTPAuthenticatorTest {
         when(OneTimePassword.getRandomNumber(EmailOTPAuthenticatorConstants.SECRET_KEY_LENGTH)).thenReturn("123456");
         emailOTPAuthenticator = PowerMockito.spy(new EmailOTPAuthenticator());
         doNothing().when(emailOTPAuthenticator, "sendOTP", anyString(), anyString(), anyString(), anyObject(),
-                anyString());
+                anyString(), anyString());
         AuthenticatorFlowStatus status = emailOTPAuthenticator.process(httpServletRequest, httpServletResponse,
                 context);
         Assert.assertEquals(status, AuthenticatorFlowStatus.INCOMPLETE);
@@ -649,7 +649,7 @@ public class EmailOTPAuthenticatorTest {
         // source is compatible with java 11.
         when(OneTimePassword.getRandomNumber(EmailOTPAuthenticatorConstants.SECRET_KEY_LENGTH)).thenReturn("123456");
         doNothing().when(emailOTPAuthenticator, "sendOTP", anyString(), anyString(), anyString(), anyObject(),
-                anyString());
+                anyString(), anyString());
         AuthenticatorFlowStatus status = emailOTPAuthenticator.process(httpServletRequest, httpServletResponse,
                 context);
         Assert.assertEquals(status, AuthenticatorFlowStatus.INCOMPLETE);
@@ -687,7 +687,7 @@ public class EmailOTPAuthenticatorTest {
         when(OneTimePassword.getRandomNumber(EmailOTPAuthenticatorConstants.SECRET_KEY_LENGTH)).thenReturn("123456");
         emailOTPAuthenticator = PowerMockito.spy(new EmailOTPAuthenticator());
         doNothing().when(emailOTPAuthenticator, "sendOTP", anyString(), anyString(), anyString(), anyObject(),
-                anyString());
+                anyString(), anyString());
         AuthenticatorFlowStatus status = emailOTPAuthenticator.process(httpServletRequest, httpServletResponse,
                 context);
         Assert.assertEquals(status, AuthenticatorFlowStatus.INCOMPLETE);


### PR DESCRIPTION
## Purpose
- Part of the fix for : https://github.com/wso2/product-is/issues/24128

## Tests
1. Configuring the params. `notificationTemplate` is the name of the Email template that we need to send the email.
```
executeStep(2, {
    authenticationOptions: '"Email OTP"',
    authenticatorParams: {
        federated: {
            'Email OTP': {
                notificationTemplate: "customEmailTemplate"
            }
        }
    }
}, {});
```
