### PR TITLE
Enhance Email OTP Authenticator with Federated and JIT Provisioned User Support

### DIFF
--- a/component/authenticator/pom.xml
+++ b/component/authenticator/pom.xml
@@ -74,6 +74,7 @@
                             org.wso2.carbon.identity.application.common.model;
                             version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.idp.mgt; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core.util; version="${carbon.identity.package.import.version.range}",
                             org.apache.oltu.oauth2.*; version="${oltu.package.import.version.range}",
                             org.wso2.carbon.identity.governance; version="${identity.governance.imp.pkg.version.range}",

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java
@@ -51,6 +51,8 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Authe
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
+import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.identity.application.common.model.JustInTimeProvisioningConfig;
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.authenticator.emailotp.config.EmailOTPUtils;
 import org.wso2.carbon.identity.authenticator.emailotp.exception.EmailOTPException;
@@ -77,6 +79,7 @@ import org.wso2.carbon.identity.mgt.mail.NotificationBuilder;
 import org.wso2.carbon.identity.mgt.mail.NotificationData;
 import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 import org.wso2.carbon.identity.recovery.util.Utils;
+import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.api.UserStoreManager;
@@ -702,7 +705,7 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
                     metaProperties.put(EmailOTPAuthenticatorConstants.SERVICE_PROVIDER_NAME,
                             context.getServiceProviderName());
                 }
-                triggerEvent(authenticatedUser, myToken, email, metaProperties, emailTemplateType);
+                triggerEvent(authenticatedUser, myToken, email, metaProperties, emailTemplateType, context);
             } else {
                 sendOTP(username, myToken, email, context, ipAddress, emailTemplateType);
             }
@@ -2382,22 +2385,37 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
     }
 
     /**
-     * Trigger event.
-     *
-     * @param user           Authenticated user.
-     * @param otpCode        The OTP code returned for the authentication request.
-     * @param sendToAddress  The email address to send the otp.
-     * @param metaProperties Meta details.
-     * @throws AuthenticationFailedException In occasions of failing to send the email to the user.
+     * Trigger notification event to send the OTP code to the user's email address.
+     * @param user           AuthenticatedUser.
+     * @param otpCode        OTP code.
+     * @param sendToAddress  Email address to send the OTP.
+     * @param metaProperties Meta properties.
+     * @param emailTemplateType   Email template type.
+     * @param context        AuthenticationContext.
+     * @throws AuthenticationFailedException If an error occurred while triggering the event.
      */
     private void triggerEvent(AuthenticatedUser user, String otpCode, String sendToAddress,
-                              Map<String, String> metaProperties, String emailTemplateType)
+                              Map<String, String> metaProperties, String emailTemplateType,
+                              AuthenticationContext context)
             throws AuthenticationFailedException {
+
+        String userName = user.getUserName();
+        String userStoreDomainName = user.getUserStoreDomain();
+        String idpLocalClaimValue = null;
+        if (context != null) {
+            String localUserName = resolveLocalUsername(getAuthenticatedUser(context), context);
+            if (StringUtils.isNotEmpty(localUserName)) {
+                userName = localUserName;
+                userStoreDomainName = resolveUserStoreDomain(getAuthenticatedUser(context), context);
+            } else {
+                idpLocalClaimValue = getIdpLocaleClaim(user, context);
+            }
+        }
 
         String eventName = IdentityEventConstants.Event.TRIGGER_NOTIFICATION;
         HashMap<String, Object> properties = new HashMap<>();
-        properties.put(IdentityEventConstants.EventProperty.USER_NAME, user.getUserName());
-        properties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, user.getUserStoreDomain());
+        properties.put(IdentityEventConstants.EventProperty.USER_NAME, userName);
+        properties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, userStoreDomainName);
         properties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, user.getTenantDomain());
         properties.put(EmailOTPAuthenticatorConstants.CODE, otpCode);
         properties.put(EmailOTPAuthenticatorConstants.TEMPLATE_TYPE, EmailOTPAuthenticatorConstants.EVENT_NAME);
@@ -2405,6 +2423,9 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
             properties.put(EmailOTPAuthenticatorConstants.TEMPLATE_TYPE, emailTemplateType);
         }
         properties.put(EmailOTPAuthenticatorConstants.ATTRIBUTE_EMAIL_SENT_TO, sendToAddress);
+        if (StringUtils.isNotEmpty(idpLocalClaimValue)) {
+            properties.put(EmailOTPAuthenticatorConstants.LOCAL_CLAIM_VALUE, idpLocalClaimValue);
+        }
 
         if (metaProperties != null) {
             for (Map.Entry<String, String> metaProperty : metaProperties.entrySet()) {
@@ -2420,6 +2441,122 @@ public class EmailOTPAuthenticator extends AbstractApplicationAuthenticator
         } catch (IdentityEventException e) {
             String errorMsg = "An error occurred while triggering the event. " + e.getMessage();
             throw new AuthenticationFailedException(errorMsg, e.getCause());
+        }
+    }
+
+    /**
+     * Retrieve the provisioned username of the authenticated user. If this is a federated scenario, the
+     * authenticated username will be same as the username in context. If the flow is for a JIT provisioned user, the
+     * provisioned username will be returned.
+     *
+     * @param authenticatedUser AuthenticatedUser.
+     * @param context           AuthenticationContext.
+     * @return Provisioned username
+     * @throws AuthenticationFailedException If an error occurred while getting the provisioned username.
+     */
+    private String resolveLocalUsername(AuthenticatedUser authenticatedUser, AuthenticationContext context)
+            throws AuthenticationFailedException {
+
+        if (!authenticatedUser.isFederatedUser()) {
+            return authenticatedUser.getUserName();
+        }
+        // If the user is federated, we need to check whether the user is already provisioned to the organization.
+        String federatedUsername = FederatedAuthenticatorUtil.getLoggedInFederatedUser(context);
+        if (StringUtils.isBlank(federatedUsername)) {
+            throw new AuthenticationFailedException("No federated user found from the authentication context.");
+        }
+        String associatedLocalUsername =
+                FederatedAuthenticatorUtil.getLocalUsernameAssociatedWithFederatedUser(MultitenantUtils.
+                        getTenantAwareUsername(federatedUsername), context);
+        if (StringUtils.isNotBlank(associatedLocalUsername)) {
+            return associatedLocalUsername;
+        }
+        return null;
+    }
+
+    /**
+     * Get the JIT provisioning userstore domain of the authenticated user.
+     *
+     * @param authenticatedUser         AuthenticatedUser.
+     * @return JIT provisioning userstore domain.
+     * @throws AuthenticationFailedException If an error occurred.
+     */
+    private String resolveUserStoreDomain(AuthenticatedUser authenticatedUser, AuthenticationContext context)
+            throws AuthenticationFailedException {
+
+        if (!authenticatedUser.isFederatedUser()) {
+            return authenticatedUser.getUserStoreDomain();
+        }
+
+        String tenantDomain = authenticatedUser.getTenantDomain();
+        String federatedIdp = authenticatedUser.getFederatedIdPName();
+        IdentityProvider idp = getIdentityProvider(federatedIdp, tenantDomain, context);
+        JustInTimeProvisioningConfig provisioningConfig = idp.getJustInTimeProvisioningConfig();
+        if (provisioningConfig == null) {
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("No JIT provisioning configs for idp: %s in tenant: %s", federatedIdp,
+                        tenantDomain));
+            }
+            return null;
+        }
+        String provisionedUserstore = provisioningConfig.getProvisioningUserStore();
+        if (log.isDebugEnabled()) {
+            log.debug(String.format("Setting userstore: %s as the provisioning userstore for user: %s in tenant: %s",
+                    provisionedUserstore, authenticatedUser.getUserName(), tenantDomain));
+        }
+        return provisionedUserstore;
+    }
+
+    /**
+     * Get locale claim value from the federated IDP.
+     *
+     * @param authenticatedUser AuthenticatedUser.
+     * @param context           AuthenticationContext.
+     * @return locale claim value.
+     * @throws AuthenticationFailedException If an error occurred while getting the locale claim value.
+     */
+    private String getIdpLocaleClaim(AuthenticatedUser authenticatedUser, AuthenticationContext context)
+            throws AuthenticationFailedException {
+
+        String tenantDomain = authenticatedUser.getTenantDomain();
+        String federatedIdp = authenticatedUser.getFederatedIdPName();
+        IdentityProvider idp = getIdentityProvider(federatedIdp, tenantDomain, context);
+
+        for (ClaimMapping claimMapping: idp.getClaimConfig().getClaimMappings()) {
+            String localeClaim = claimMapping.getLocalClaim().getClaimUri();
+            if (EmailOTPAuthenticatorConstants.LOCALITY_CLAIM.equals(localeClaim) ||
+                    EmailOTPAuthenticatorConstants.LOCAL_CLAIM.equals(localeClaim)) {
+                Map<String, String> userAttributes = FrameworkUtils.getClaimMappings(authenticatedUser.getUserAttributes(), false);
+                return userAttributes.get(claimMapping.getRemoteClaim().getClaimUri());
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get Identity Provider by name.
+     *
+     * @param idpName      Name of the IDP.
+     * @param tenantDomain Tenant domain of the IDP.
+     * @param context      AuthenticationContext.
+     * @return IdentityProvider.
+     * @throws AuthenticationFailedException If an error occurred while getting the IDP.
+     */
+    private IdentityProvider getIdentityProvider(String idpName, String tenantDomain,
+                                                 AuthenticationContext context) throws
+            AuthenticationFailedException {
+
+        try {
+            IdentityProvider idp = EmailOTPServiceDataHolder.getInstance().getIdpManager()
+                    .getIdPByName(idpName, tenantDomain);
+            if (idp == null) {
+                throw new AuthenticationFailedException(String.format(
+                        "No IDP found with the name IDP: %s in tenant: %s", idpName, tenantDomain));
+            }
+            return idp;
+        } catch (IdentityProviderManagementException e) {
+            throw new AuthenticationFailedException(String.format(
+                    "Error occurred while getting IDP: %s from tenant: %s", idpName, tenantDomain));
         }
     }
 

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorConstants.java
@@ -140,6 +140,7 @@ public class EmailOTPAuthenticatorConstants {
     public static final String TEMPLATE_TYPE = "TEMPLATE_TYPE";
     public static final String EVENT_NAME = "EmailOTP";
     public static final String ATTRIBUTE_EMAIL_SENT_TO = "send-to";
+    public static final String LOCAL_CLAIM_VALUE = "locale";
     public static final String OTP_GENERATED_TIME = "tokenGeneratedTime";
     public static final String TOKEN_EXPIRE_TIME_IN_MILIS = "tokenExpirationTime";
     public static final String OTP_EXPIRE_TIME_DEFAULT = "300000";
@@ -165,6 +166,8 @@ public class EmailOTPAuthenticatorConstants {
     public static final String ACCOUNT_LOCKED_CLAIM = "http://wso2.org/claims/identity/accountLocked";
     public static final String ACCOUNT_UNLOCK_TIME_CLAIM = "http://wso2.org/claims/identity/unlockTime";
     public static final String ACCOUNT_LOCKED_REASON_CLAIM_URI = "http://wso2.org/claims/identity/lockedReason";
+    public static final String LOCALITY_CLAIM = "http://wso2.org/claims/locality";
+    public static final String LOCAL_CLAIM = "http://wso2.org/claims/local";
     public static final String SHOW_AUTH_FAILURE_REASON = "showAuthFailureReason";
     public static final String ENABLE_ACCOUNT_LOCKING_FOR_FAILED_ATTEMPTS = "EnableAccountLockingForFailedAttempts";
     public static final String PROPERTY_LOGIN_FAIL_TIMEOUT_RATIO = "account.lock.handler.login.fail.timeout.ratio";

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/internal/EmailOTPAuthenticatorServiceComponent.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/internal/EmailOTPAuthenticatorServiceComponent.java
@@ -32,6 +32,7 @@ import org.wso2.carbon.identity.authenticator.emailotp.EmailOTPAuthenticator;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
+import org.wso2.carbon.idp.mgt.IdpManager;
 import org.wso2.carbon.user.core.service.RealmService;
 
 import java.util.Hashtable;
@@ -134,5 +135,22 @@ public class EmailOTPAuthenticatorServiceComponent {
     protected void unsetAccountLockService(AccountLockService accountLockService) {
 
         EmailOTPServiceDataHolder.getInstance().setAccountLockService(null);
+    }
+
+    @Reference(
+            name = "org.wso2.carbon.idp.mgt.IdpManager",
+            service = IdpManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetIdentityProviderManagementService"
+    )
+    protected void setIdentityProviderManagementService(IdpManager idpManager) {
+
+        EmailOTPServiceDataHolder.getInstance().setIdpManager(idpManager);
+    }
+
+    protected void unsetIdentityProviderManagementService(IdpManager idpManager) {
+
+        EmailOTPServiceDataHolder.getInstance().setIdpManager(null);
     }
 }

--- a/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/internal/EmailOTPServiceDataHolder.java
+++ b/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/internal/EmailOTPServiceDataHolder.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.authenticator.emailotp.internal;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockService;
+import org.wso2.carbon.idp.mgt.IdpManager;
 import org.wso2.carbon.user.core.service.RealmService;
 
 /**
@@ -33,6 +34,7 @@ public class EmailOTPServiceDataHolder {
     private IdentityEventService identityEventService;
     private IdentityGovernanceService identityGovernanceService;
     private RealmService realmService;
+    private IdpManager idpManager;
 
     public static EmailOTPServiceDataHolder getInstance() {
 
@@ -107,5 +109,28 @@ public class EmailOTPServiceDataHolder {
     public void setAccountLockService(AccountLockService accountLockService) {
 
         this.accountLockService = accountLockService;
+    }
+
+    /**
+     * Get IdpManager.
+     *
+     * @return IdpManager.
+     */
+    public IdpManager getIdpManager() {
+
+        if (idpManager == null) {
+            throw new RuntimeException("IdpManager not available. Component is not started properly.");
+        }
+        return idpManager;
+    }
+
+    /**
+     * Set IdpManager.
+     *
+     * @param idpManager IdpManager.
+     */
+    public void setIdpManager(IdpManager idpManager) {
+
+        this.idpManager = idpManager;
     }
 }

--- a/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorTest.java
+++ b/component/authenticator/src/test/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticatorTest.java
@@ -1239,4 +1239,304 @@ public class EmailOTPAuthenticatorTest {
         context.setSequenceConfig(sequenceConfig);
         context.setCurrentStep(1);
     }
+
+    @Test(description = "Test case for processValidUserToken() method")
+    public void testProcessValidUserToken() throws Exception {
+
+        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+        authenticatedUser.setUserName(USER_NAME);
+        authenticatedUser.setAuthenticatedSubjectIdentifier(USER_NAME);
+        context.setProperty(EmailOTPAuthenticatorConstants.OTP_TOKEN, "123456");
+        context.setProperty(EmailOTPAuthenticatorConstants.EMAILOTP_ACCESS_TOKEN, "access-token");
+
+        Whitebox.invokeMethod(emailOTPAuthenticator, "processValidUserToken", context, authenticatedUser);
+
+        Assert.assertEquals(context.getProperty(EmailOTPAuthenticatorConstants.OTP_TOKEN), "");
+        Assert.assertEquals(context.getProperty(EmailOTPAuthenticatorConstants.EMAILOTP_ACCESS_TOKEN), "");
+        Assert.assertEquals(context.getSubject(), authenticatedUser);
+    }
+
+    @Test(description = "Test case for isBackUpCodeValid() method with valid backup code")
+    public void testIsBackUpCodeValidWithValidCode() throws Exception {
+
+        String[] savedOTPs = {"code1", "code2", "code3"};
+        String userToken = "code2";
+
+        boolean result = Whitebox.invokeMethod(emailOTPAuthenticator, "isBackUpCodeValid", savedOTPs, userToken);
+
+        Assert.assertTrue(result);
+    }
+
+    @Test(description = "Test case for isBackUpCodeValid() method with invalid backup code")
+    public void testIsBackUpCodeValidWithInvalidCode() throws Exception {
+
+        String[] savedOTPs = {"code1", "code2", "code3"};
+        String userToken = "invalidCode";
+
+        boolean result = Whitebox.invokeMethod(emailOTPAuthenticator, "isBackUpCodeValid", savedOTPs, userToken);
+
+        Assert.assertFalse(result);
+    }
+
+    @Test(description = "Test case for isBackUpCodeValid() method with empty backup codes")
+    public void testIsBackUpCodeValidWithEmptyBackupCodes() throws Exception {
+
+        String[] savedOTPs = {};
+        String userToken = "code1";
+
+        boolean result = Whitebox.invokeMethod(emailOTPAuthenticator, "isBackUpCodeValid", savedOTPs, userToken);
+
+        Assert.assertFalse(result);
+    }
+
+    @Test(description = "Test case for isBackupCodeEnabled() method when backup code is enabled")
+    public void testIsBackupCodeEnabledWhenEnabled() throws Exception {
+
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put(EmailOTPAuthenticatorConstants.BACKUP_CODE, "true");
+        context.setAuthenticatorProperties(parameters);
+
+        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+        authenticatedUser.setUserName(USER_NAME);
+        authenticatedUser.setAuthenticatedSubjectIdentifier(USER_NAME);
+
+        StepConfig stepConfig = new StepConfig();
+        stepConfig.setAuthenticatedUser(authenticatedUser);
+        stepConfig.setSubjectAttributeStep(true);
+        stepConfig.setAuthenticatedIdP("LOCAL");
+        Map<Integer, StepConfig> stepConfigMap = new HashMap<>();
+        stepConfigMap.put(1, stepConfig);
+
+        SequenceConfig sequenceConfig = new SequenceConfig();
+        sequenceConfig.setStepMap(stepConfigMap);
+        context.setSequenceConfig(sequenceConfig);
+
+        when(EmailOTPUtils.getConfiguration(context, EmailOTPAuthenticatorConstants.BACKUP_CODE))
+                .thenReturn("true");
+
+        boolean result = Whitebox.invokeMethod(emailOTPAuthenticator, "isBackupCodeEnabled", context);
+
+        Assert.assertTrue(result);
+    }
+
+    @Test(description = "Test case for isBackupCodeEnabled() method when backup code is disabled")
+    public void testIsBackupCodeEnabledWhenDisabled() throws Exception {
+
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put(EmailOTPAuthenticatorConstants.BACKUP_CODE, "false");
+        context.setAuthenticatorProperties(parameters);
+
+        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+        authenticatedUser.setUserName(USER_NAME);
+        authenticatedUser.setAuthenticatedSubjectIdentifier(USER_NAME);
+
+        StepConfig stepConfig = new StepConfig();
+        stepConfig.setAuthenticatedUser(authenticatedUser);
+        stepConfig.setSubjectAttributeStep(true);
+        stepConfig.setAuthenticatedIdP("LOCAL");
+        Map<Integer, StepConfig> stepConfigMap = new HashMap<>();
+        stepConfigMap.put(1, stepConfig);
+
+        SequenceConfig sequenceConfig = new SequenceConfig();
+        sequenceConfig.setStepMap(stepConfigMap);
+        context.setSequenceConfig(sequenceConfig);
+
+        when(EmailOTPUtils.getConfiguration(context, EmailOTPAuthenticatorConstants.BACKUP_CODE))
+                .thenReturn("false");
+
+        boolean result = Whitebox.invokeMethod(emailOTPAuthenticator, "isBackupCodeEnabled", context);
+
+        Assert.assertFalse(result);
+    }
+
+    @Test(description = "Test case for getAuthenticatedUser() method")
+    public void testGetAuthenticatedUser() throws Exception {
+
+        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+        authenticatedUser.setUserName(USER_NAME);
+        authenticatedUser.setAuthenticatedSubjectIdentifier(USER_NAME);
+
+        StepConfig stepConfig = new StepConfig();
+        stepConfig.setAuthenticatedUser(authenticatedUser);
+        stepConfig.setSubjectAttributeStep(true);
+        Map<Integer, StepConfig> stepConfigMap = new HashMap<>();
+        stepConfigMap.put(1, stepConfig);
+
+        SequenceConfig sequenceConfig = new SequenceConfig();
+        sequenceConfig.setStepMap(stepConfigMap);
+        context.setSequenceConfig(sequenceConfig);
+
+        AuthenticatedUser result = Whitebox.invokeMethod(emailOTPAuthenticator, "getAuthenticatedUser", context);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.getUserName(), USER_NAME);
+    }
+
+    @Test(description = "Test case for getAuthenticatedUser() method with last authenticated user")
+    public void testGetAuthenticatedUserWithLastAuthenticatedUser() throws Exception {
+
+        AuthenticatedUser authenticatedUser = new AuthenticatedUser();
+        authenticatedUser.setUserName(USER_NAME);
+        authenticatedUser.setAuthenticatedSubjectIdentifier(USER_NAME);
+
+        StepConfig stepConfig = new StepConfig();
+        stepConfig.setAuthenticatedUser(authenticatedUser);
+        stepConfig.setSubjectAttributeStep(true);
+        Map<Integer, StepConfig> stepConfigMap = new HashMap<>();
+        stepConfigMap.put(1, stepConfig);
+
+        SequenceConfig sequenceConfig = new SequenceConfig();
+        sequenceConfig.setStepMap(stepConfigMap);
+        context.setSequenceConfig(sequenceConfig);
+
+        AuthenticatedUser result = Whitebox.invokeMethod(emailOTPAuthenticator, "getAuthenticatedUser", context);
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.getUserName(), USER_NAME);
+    }
+
+    @Test(description = "Test case for verifyUserExists() method when user exists")
+    public void testVerifyUserExistsWhenUserExists() throws Exception {
+
+        String username = USER_NAME;
+        String tenantDomain = TENANT_DOMAIN;
+
+        when(IdentityTenantUtil.getTenantId(tenantDomain)).thenReturn(TENANT_ID);
+        when(IdentityTenantUtil.getRealmService()).thenReturn(realmService);
+        when(realmService.getTenantUserRealm(TENANT_ID)).thenReturn(userRealm);
+        when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
+        when(userStoreManager.isExistingUser(username)).thenReturn(true);
+
+        // Should not throw exception
+        Whitebox.invokeMethod(emailOTPAuthenticator, "verifyUserExists", username, tenantDomain);
+    }
+
+    @Test(description = "Test case for verifyUserExists() method when user does not exist",
+            expectedExceptions = AuthenticationFailedException.class)
+    public void testVerifyUserExistsWhenUserDoesNotExist() throws Exception {
+
+        String username = USER_NAME;
+        String tenantDomain = TENANT_DOMAIN;
+
+        when(IdentityTenantUtil.getTenantId(tenantDomain)).thenReturn(TENANT_ID);
+        when(IdentityTenantUtil.getRealmService()).thenReturn(realmService);
+        when(realmService.getTenantUserRealm(TENANT_ID)).thenReturn(userRealm);
+        when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
+        when(userStoreManager.isExistingUser(username)).thenReturn(false);
+
+        Whitebox.invokeMethod(emailOTPAuthenticator, "verifyUserExists", username, tenantDomain);
+    }
+
+    @Test(description = "Test case for getRedirectURL() method with query params")
+    public void testGetRedirectURLWithQueryParams() throws Exception {
+
+        String baseURI = "https://localhost:9443/emailotpauthenticationendpoint/emailotp.jsp";
+        String queryParams = "sessionDataKey=12345&authenticators=EmailOTP";
+
+        String result = Whitebox.invokeMethod(emailOTPAuthenticator, "getRedirectURL", baseURI, queryParams);
+
+        Assert.assertTrue(result.contains(baseURI));
+        Assert.assertTrue(result.contains(queryParams));
+        Assert.assertTrue(result.contains("&authenticators=EmailOTP"));
+    }
+
+    @Test(description = "Test case for getRedirectURL() method without query params")
+    public void testGetRedirectURLWithoutQueryParams() throws Exception {
+
+        String baseURI = "https://localhost:9443/emailotpauthenticationendpoint/emailotp.jsp";
+        String queryParams = "";
+
+        String result = Whitebox.invokeMethod(emailOTPAuthenticator, "getRedirectURL", baseURI, queryParams);
+
+        Assert.assertTrue(result.contains(baseURI));
+        Assert.assertTrue(result.contains("?authenticators=EmailOTP"));
+    }
+
+    @Test(description = "Test case for getEmailOTPLength() method with default value")
+    public void testGetEmailOTPLengthWithDefaultValue() throws Exception {
+
+        Map<String, String> authenticatorProperties = new HashMap<>();
+
+        int result = Whitebox.invokeMethod(emailOTPAuthenticator, "getEmailOTPLength", authenticatorProperties);
+
+        Assert.assertEquals(result, EmailOTPAuthenticatorConstants.NUMBER_DIGIT);
+    }
+
+    @Test(description = "Test case for getEmailOTPLength() method with custom value")
+    public void testGetEmailOTPLengthWithCustomValue() throws Exception {
+
+        Map<String, String> authenticatorProperties = new HashMap<>();
+        authenticatorProperties.put(EmailOTPAuthenticatorConstants.EMAIL_OTP_LENGTH, "8");
+
+        int result = Whitebox.invokeMethod(emailOTPAuthenticator, "getEmailOTPLength", authenticatorProperties);
+
+        Assert.assertEquals(result, 8);
+    }
+
+    @Test(description = "Test case for getEmailOTPLength() method with invalid value")
+    public void testGetEmailOTPLengthWithInvalidValue() throws Exception {
+
+        Map<String, String> authenticatorProperties = new HashMap<>();
+        authenticatorProperties.put(EmailOTPAuthenticatorConstants.EMAIL_OTP_LENGTH, "20");
+
+        int result = Whitebox.invokeMethod(emailOTPAuthenticator, "getEmailOTPLength", authenticatorProperties);
+
+        // Should return default value when out of range
+        Assert.assertEquals(result, EmailOTPAuthenticatorConstants.NUMBER_DIGIT);
+    }
+
+    @Test(description = "Test case for getEmailOTPExpiryTime() method with default value")
+    public void testGetEmailOTPExpiryTimeWithDefaultValue() throws Exception {
+
+        Map<String, String> authenticatorProperties = new HashMap<>();
+
+        int result = Whitebox.invokeMethod(emailOTPAuthenticator, "getEmailOTPExpiryTime", authenticatorProperties);
+
+        Assert.assertEquals(result, Integer.parseInt(EmailOTPAuthenticatorConstants.OTP_EXPIRE_TIME_DEFAULT));
+    }
+
+    @Test(description = "Test case for getEmailOTPExpiryTime() method with custom value")
+    public void testGetEmailOTPExpiryTimeWithCustomValue() throws Exception {
+
+        Map<String, String> authenticatorProperties = new HashMap<>();
+        authenticatorProperties.put(EmailOTPAuthenticatorConstants.EMAIL_OTP_EXPIRY_TIME, "10");
+
+        int result = Whitebox.invokeMethod(emailOTPAuthenticator, "getEmailOTPExpiryTime", authenticatorProperties);
+
+        Assert.assertEquals(result, 10 * 60 * 1000);
+    }
+
+    @Test(description = "Test case for getMultiOptionURIQueryParam() method with multiOptionURI")
+    public void testGetMultiOptionURIQueryParamWithValue() throws Exception {
+
+        when(httpServletRequest.getParameter(EmailOTPAuthenticatorConstants.MULTI_OPTION_URI))
+                .thenReturn("https://localhost:9443/commonauth");
+
+        String result = Whitebox.invokeMethod(emailOTPAuthenticator, "getMultiOptionURIQueryParam",
+                httpServletRequest);
+
+        Assert.assertTrue(result.contains("&multiOptionURI="));
+        Assert.assertTrue(result.contains("https"));
+    }
+
+    @Test(description = "Test case for getMultiOptionURIQueryParam() method without multiOptionURI")
+    public void testGetMultiOptionURIQueryParamWithoutValue() throws Exception {
+
+        when(httpServletRequest.getParameter(EmailOTPAuthenticatorConstants.MULTI_OPTION_URI))
+                .thenReturn(null);
+
+        String result = Whitebox.invokeMethod(emailOTPAuthenticator, "getMultiOptionURIQueryParam",
+                httpServletRequest);
+
+        Assert.assertEquals(result, "");
+    }
+
+    @Test(description = "Test case for getMultiOptionURIQueryParam() method with null request")
+    public void testGetMultiOptionURIQueryParamWithNullRequest() throws Exception {
+
+        String result = Whitebox.invokeMethod(emailOTPAuthenticator, "getMultiOptionURIQueryParam",
+                (HttpServletRequest) null);
+
+        Assert.assertEquals(result, "");
+    }
 }


### PR DESCRIPTION
## Related Issue
- https://github.com/wso2/product-is/issues/20606

## Implementation
This pull request enhances the Email OTP authenticator by improving support for federated and JIT-provisioned users, especially in scenarios involving identity providers (IDPs). The main changes introduce new logic to resolve local usernames, userstore domains, and locale claims for federated users, and add integration with the IDP management service. These updates ensure that notification events are triggered with accurate user information and locale data, improving compatibility and user experience in federated authentication flows.

**Federated/JIT User Handling:**

* Added logic in `EmailOTPAuthenticator.java` to resolve the local username and userstore domain for federated users, ensuring correct identification when triggering notification events. Also added retrieval of locale claims from federated IDPs. [[1]](diffhunk://#diff-64287a507e2f28fd63b8a663df5180ba9e5091fc3209309f34dcaab1efdd52f6L2385-R2428) [[2]](diffhunk://#diff-64287a507e2f28fd63b8a663df5180ba9e5091fc3209309f34dcaab1efdd52f6R2447-R2562)

* Updated the `triggerEvent` method signature to accept `AuthenticationContext`, and enhanced its implementation to use the new federated/JIT user resolution logic and locale claim retrieval. [[1]](diffhunk://#diff-64287a507e2f28fd63b8a663df5180ba9e5091fc3209309f34dcaab1efdd52f6L705-R708) [[2]](diffhunk://#diff-64287a507e2f28fd63b8a663df5180ba9e5091fc3209309f34dcaab1efdd52f6L2385-R2428)

**IDP Management Integration:**

* Registered and injected the `IdpManager` service in `EmailOTPAuthenticatorServiceComponent.java` and exposed it via `EmailOTPServiceDataHolder.java` for use in authenticator logic. [[1]](diffhunk://#diff-7df341067c0eaffcccb6e9f261d7d3da2a8f35e6a5c61373e10ec8701a8650f8R35) [[2]](diffhunk://#diff-7df341067c0eaffcccb6e9f261d7d3da2a8f35e6a5c61373e10ec8701a8650f8R139-R155) [[3]](diffhunk://#diff-e52e36673569ff2d06146301081b872477218fcfa6c357b14c164d68b6cffd02R24) [[4]](diffhunk://#diff-e52e36673569ff2d06146301081b872477218fcfa6c357b14c164d68b6cffd02R37) [[5]](diffhunk://#diff-e52e36673569ff2d06146301081b872477218fcfa6c357b14c164d68b6cffd02R113-R135)

* Updated OSGi import and Maven configuration to include the new `org.wso2.carbon.idp.mgt` dependency for IDP management. [[1]](diffhunk://#diff-588c885c2f8905fecafd52f125d28a6d79eb4f9312d72bf03b9a0e0fd3a6460dR77) [[2]](diffhunk://#diff-64287a507e2f28fd63b8a663df5180ba9e5091fc3209309f34dcaab1efdd52f6R82)

**Constants and Claims:**

* Added new constants in `EmailOTPAuthenticatorConstants.java` for locale claim handling and locality claims, supporting improved claim mapping for federated users. [[1]](diffhunk://#diff-90fa20daa69f16947ca07cbb365a07e962958087e68e3e629940ff1b6fbb477aR143) [[2]](diffhunk://#diff-90fa20daa69f16947ca07cbb365a07e962958087e68e3e629940ff1b6fbb477aR169-R170)